### PR TITLE
Add a single resource field and basic template overrides 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,7 @@ for the primary and format types at:
     cd ..
   ``` 
   8. Create the .ini file as per the normal CKAN installation instructions and modify as noted above.
+  
+  9. Create an organization with the URL statcan and the name Statistics Canada
 
     

--- a/ckanext/stcndm/logic/cubes.py
+++ b/ckanext/stcndm/logic/cubes.py
@@ -164,7 +164,7 @@ def get_cube_list_by_subject(context, data_dict):
         return output
 
 
-def register_cube(context, data_dict):  # TODO: we need to talk to the cube team about this, not required now.
+def register_cube(context, data_dict):
     # noinspection PyUnresolvedReferences
     """
     Register a cube in the rgcube organization.  Automatically populate subjectcode fields based on
@@ -197,7 +197,7 @@ def register_cube(context, data_dict):  # TODO: we need to talk to the cube team
     product_id = _get_action('ndm_get_next_cubeid')(context, data_dict)
 
     name = '{product_id}'.format(product_id=product_id)
-    org = 'rgcube'
+    org = 'statcan'
     extras = []
 
     time = datetime.datetime.today()

--- a/ckanext/stcndm/schemas/code.yaml
+++ b/ckanext/stcndm/schemas/code.yaml
@@ -30,4 +30,9 @@ dataset_fields:
     fr: Étiquette descriptive
 preset: fluent_text
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/conf_service.yaml
+++ b/ckanext/stcndm/schemas/conf_service.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/corrections.yaml
+++ b/ckanext/stcndm/schemas/corrections.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/daily.yaml
+++ b/ckanext/stcndm/schemas/daily.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/indicator.yaml
+++ b/ckanext/stcndm/schemas/indicator.yaml
@@ -14,4 +14,9 @@ languages_label:
 
 dataset_fields: []
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/issue.yaml
+++ b/ckanext/stcndm/schemas/issue.yaml
@@ -337,4 +337,9 @@ dataset_fields:
 #    en: Volume and Number
 #    fr: Volume et nombre
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/publication.yaml
+++ b/ckanext/stcndm/schemas/publication.yaml
@@ -71,7 +71,7 @@ dataset_fields:
     - label:
         en: Publication
         fr: Publication
-      value: ''
+      value: 'pub'
   required: true
 
 # 9
@@ -327,4 +327,9 @@ dataset_fields:
 #    en: Volume and Number
 #    fr: Volume et nombre
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/pumf.yaml
+++ b/ckanext/stcndm/schemas/pumf.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/subject.yaml
+++ b/ckanext/stcndm/schemas/subject.yaml
@@ -69,4 +69,9 @@ dataset_fields:
     fr: Ancien sujet
   preset: shortcode_multivalue
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/unregistered.yaml
+++ b/ckanext/stcndm/schemas/unregistered.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/video.yaml
+++ b/ckanext/stcndm/schemas/video.yaml
@@ -16,4 +16,9 @@ dataset_fields:
 - field_name: product_type_code
   preset: ndm_products
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/schemas/view.yaml
+++ b/ckanext/stcndm/schemas/view.yaml
@@ -327,4 +327,9 @@ dataset_fields:
     en: Volume and Number
     fr: Volume et nombre
 
-resource_fields: []
+resource_fields:
+# XXX a quick hack to allow the creation of one resource to make the
+# package controller happy. a better fix would be to disable the resource
+# edit page by overriding the controller
+- field_name: url
+  required: true

--- a/ckanext/stcndm/templates/package/read_base.html
+++ b/ckanext/stcndm/templates/package/read_base.html
@@ -1,0 +1,68 @@
+{% extends "package/base.html" %}
+
+{% block subtitle %}{{ pkg.title or pkg.name }} - {{ super() }}{% endblock %}
+
+{% block links -%}
+  {{ super() }}
+  <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(controller='package', action='read', id=pkg.id, format='rdf', qualified=True) }}"/>
+{% endblock -%}
+
+{% block head_extras -%}
+  {{ super() }}
+  {% set description = pkg.notes|forceescape %}
+  <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
+  <meta property="og:description" content="{{ description|forceescape|trim }}">
+{% endblock -%}
+
+{% block content_action %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}
+  {% endif %}
+{% endblock %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
+  {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
+  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
+  {{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }}
+{% endblock %}
+
+{% block primary_content_inner %}
+    {% block package_revision_info %}
+      {% if c.revision_date %}
+        <div class="module info alert alert-info">
+          <p class="module-content">
+            {% set timestamp = h.render_datetime(c.revision_date, with_hours=True) %}
+            {% set url = h.url(controller='package', action='read', id=pkg.name) %}
+
+            {% trans timestamp=timestamp, url=url %}This is an old revision of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current revision</a>.{% endtrans %}
+          </p>
+        </div>
+      {% endif %}
+    {% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+
+  {% block secondary_help_content %}{% endblock %}
+
+  {% block package_info %}
+    {% snippet 'package/snippets/info.html', pkg=pkg %}
+  {% endblock %}
+
+  {% block package_organization %}
+    {% if pkg.organization %}
+      {% set org = h.get_organization(pkg.organization.name) %}
+      {% snippet "snippets/organization.html", organization=org, has_context_title=true %}
+    {% endif %}
+  {% endblock %}
+
+  {% block package_social %}
+    {% snippet "snippets/social.html" %}
+  {% endblock %}
+
+  {% block package_license %}
+    {% snippet "snippets/license.html", pkg_dict=pkg %}
+  {% endblock %}
+
+{% endblock %}

--- a/ckanext/stcndm/templates/snippets/package_item.html
+++ b/ckanext/stcndm/templates/snippets/package_item.html
@@ -1,0 +1,78 @@
+{#
+Displays a single of dataset.
+
+package        - A package to display.
+item_class     - The class name to use on the list item.
+hide_resources - If true hides the resources (default: false).
+banner         - If true displays a popular banner (default: false).
+truncate       - The length to trucate the description to (default: 180)
+truncate_title - The length to truncate the title to (default: 80).
+
+Example:
+
+  {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
+
+#}
+{% set truncate = truncate or 180 %}
+{% set truncate_title = truncate_title or 80 %}
+{% set title = package.title or package.name %}
+{% set notes = package.notes %}
+
+{% block package_item %}
+  <li class="{{ item_class or "dataset-item" }}">
+    {% block content %}
+      <div class="dataset-content">
+        {% block heading %}
+          <h3 class="dataset-heading">
+            {% block heading_private %}
+              {% if package.private %}
+                <span class="dataset-private label label-inverse">
+                  <i class="icon-lock"></i>
+                  {{ _('Private') }}
+                </span>
+              {% endif %}
+            {% endblock %}
+            {% block heading_title %}
+              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}
+            {% endblock %}
+            {% block heading_meta %}
+              {% if package.get('state', '').startswith('draft') %}
+                <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('state', '').startswith('deleted') %}
+                <span class="label label-important">{{ _('Deleted') }}</span>
+              {% endif %}
+              {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+            {% endblock %}
+          </h3>
+        {% endblock %}
+        {% block banner %}
+          {% if banner %}
+            <span class="banner">{{ _('Popular') }}</span>
+          {% endif %}
+        {% endblock %}
+        {% block notes %}
+          {% if notes %}
+            <div>{{ notes|urlize }}</div>
+          {% else %}
+            <p class="empty">{{ _("This dataset has no description") }}</p>
+          {% endif %}
+        {% endblock %}
+      </div>
+      {% block resources %}
+        {% if package.resources and not hide_resources %}
+          {% block resources_outer %}
+            <ul class="dataset-resources unstyled">
+              {% block resources_inner %}
+                {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+                <li>
+                  <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
+                </li>
+                {% endfor %}
+              {% endblock %}
+            </ul>
+          {% endblock %}
+        {% endif %}
+      {% endblock %}
+    {% endblock %}
+  </li>
+{% endblock %}


### PR DESCRIPTION
Note that the default markdown_extract function takes a string, so be sure to extract from dictionary first before passing to this helper in the templates.
