### PR TITLE
Start of multilingual core field support.

### DIFF
--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 import ckan.plugins as p
-import ckan.lib.helpers as ckan_helpers
 import ckanext.stcndm.logic.common as common
 import ckanext.stcndm.logic.cubes as cubes
 import ckanext.stcndm.logic.daily as daily
@@ -10,6 +9,7 @@ import ckanext.stcndm.logic.views as views
 
 from ckanext.stcndm import validators
 from ckanext.stcndm import helpers
+from ckanext.scheming.helpers import scheming_language_text
 
 
 class STCNDMPlugin(p.SingletonPlugin):
@@ -87,7 +87,6 @@ class STCNDMPlugin(p.SingletonPlugin):
         Ensure that (if available) the correct language strings
         are used for core CKAN fields.
         """
-        default_language = u'en'
         fields_to_fluent = (
             u'title',
             u'notes',
@@ -95,20 +94,8 @@ class STCNDMPlugin(p.SingletonPlugin):
             u'resources'
         )
 
-        current_language = ckan_helpers.lang()
-
         for field in fields_to_fluent:
             if field in pkg_dict and isinstance(pkg_dict[field], dict):
-                field_value = pkg_dict[field]
-                if not field_value:
-                    pkg_dict[field] = None
-                elif current_language in field_value:
-                    pkg_dict[field] = field_value[current_language]
-                elif default_language in field:
-                    pkg_dict[field] = field_value[default_language]
-                else:
-                    # Use *any* language that's available.
-                    # Do we really want to do this?
-                    pkg_dict[field] = next(field_value.itervalues())
+                pkg_dict[field] = scheming_language_text(pkg_dict[field])
 
         return pkg_dict

--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -1,15 +1,16 @@
-
+#!/usr/bin/env python
+# encoding: utf-8
 import ckan.plugins as p
-import ckanext.stcndm.logic.codesets as codesets
+import ckan.lib.helpers as ckan_helpers
 import ckanext.stcndm.logic.common as common
 import ckanext.stcndm.logic.cubes as cubes
 import ckanext.stcndm.logic.daily as daily
-import ckanext.stcndm.logic.publications as pubs
 import ckanext.stcndm.logic.subjects as subjects
 import ckanext.stcndm.logic.views as views
 
 from ckanext.stcndm import validators
 from ckanext.stcndm import helpers
+
 
 class STCNDMPlugin(p.SingletonPlugin):
     p.implements(p.IActions)
@@ -17,6 +18,7 @@ class STCNDMPlugin(p.SingletonPlugin):
     p.implements(p.IPackageController, inherit=True)
     p.implements(p.IValidators)
     p.implements(p.ITemplateHelpers)
+    p.implements(p.IPackageController)
 
     def update_config(self, config):
         """
@@ -79,3 +81,34 @@ class STCNDMPlugin(p.SingletonPlugin):
         return {
             "codeset_choices": helpers.codeset_choices,
         }
+
+    def before_view(self, pkg_dict):
+        """
+        Ensure that (if available) the correct language strings
+        are used for core CKAN fields.
+        """
+        default_language = u'en'
+        fields_to_fluent = (
+            u'title',
+            u'notes',
+            u'name',
+            u'resources'
+        )
+
+        current_language = ckan_helpers.lang()
+
+        for field in fields_to_fluent:
+            if field in pkg_dict and isinstance(pkg_dict[field], dict):
+                field_value = pkg_dict[field]
+                if not field_value:
+                    pkg_dict[field] = None
+                elif current_language in field_value:
+                    pkg_dict[field] = field_value[current_language]
+                elif default_language in field:
+                    pkg_dict[field] = field_value[default_language]
+                else:
+                    # Use *any* language that's available.
+                    # Do we really want to do this?
+                    pkg_dict[field] = next(field_value.itervalues())
+
+        return pkg_dict

--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -89,9 +89,7 @@ class STCNDMPlugin(p.SingletonPlugin):
         """
         fields_to_fluent = (
             u'title',
-            u'notes',
-            u'name',
-            u'resources'
+            u'notes'
         )
 
         for field in fields_to_fluent:


### PR DESCRIPTION
Approach #1; Override package values using an IPackageController
after_view() handler.

Currently tries to use the CKAN current user locale, then english,
then _any_ that's available if English can't be found.

<img width="566" alt="package_en" src="https://cloud.githubusercontent.com/assets/72590/8936780/3d099c20-3522-11e5-9162-ae93cc373241.PNG">
<img width="602" alt="package_fr" src="https://cloud.githubusercontent.com/assets/72590/8936781/3d2fabfe-3522-11e5-97af-0f1cc4c1253e.PNG">
<img width="608" alt="search_en" src="https://cloud.githubusercontent.com/assets/72590/8936782/3d445bf8-3522-11e5-9575-ad4b5b82d2c8.PNG">
<img width="579" alt="search_fr" src="https://cloud.githubusercontent.com/assets/72590/8936783/3d4b6678-3522-11e5-9937-c8b433d0580d.PNG">
