### PR TITLE
Added references to repeating text validators

### DIFF
--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -15,6 +15,7 @@ from dateutil.parser import parse
 from ckan.plugins.toolkit import _
 from ckan.plugins.toolkit import ValidationError
 from ckanext.stcndm import validators
+from ckanext.repeating import validators as repeating_validators
 from ckanext.stcndm import helpers
 from ckanext.scheming.helpers import (
     scheming_language_text,
@@ -254,6 +255,8 @@ class STCNDMPlugin(p.SingletonPlugin):
             "survey_create_name": validators.survey_create_name,
             "valid_parent_slug": validators.valid_parent_slug,
             "view_create_name": validators.view_create_name,
+            "repeating_text": repeating_validators.repeating_text,
+            "repeating_text_output": repeating_validators.repeating_text_output,
         }
 
     def get_helpers(self):

--- a/ckanext/stcndm/schemas/geodescriptor.yaml
+++ b/ckanext/stcndm/schemas/geodescriptor.yaml
@@ -45,7 +45,6 @@ dataset_fields:
   label:
     en: Product ID Old
     fr: Ancien ID du produit
-  required: true
   schema_field_type: string
   schema_multivalued: true
   schema_extras: true


### PR DESCRIPTION
## The project now requires the ckanext-repeating extension. Be sure to add it if you haven't already

This is needed in order to import PUMFs which use the repeating_text validator.

Also changed product_id_old to no longer be required for geodescriptors.

Changes were needed to be able to import pumfs and geodescriptors jsonl files
