### PR TITLE
reworked CKAN schema

### DIFF
--- a/ckanext/stcndm/bin/massage_analyticals.py
+++ b/ckanext/stcndm/bin/massage_analyticals.py
@@ -46,6 +46,15 @@ while i < n:
             print json.dumps(format_out)
 
         elif len(line['productidnew_bi_strs']) == 15:
+            if line.get('title_en_txts', ''):
+                product_out = do_product(line)
+                product_out['type'] = u'publication'
+                product_out['name'] = u'{type}-{product_id}'.format(
+                        type=product_out['type'],
+                        product_id=product_out['product_id_new']
+                    ).lower()
+                print json.dumps(product_out)
+
             release_out = do_release(line)
             print json.dumps(release_out)
 

--- a/ckanext/stcndm/bin/massage_product.py
+++ b/ckanext/stcndm/bin/massage_product.py
@@ -224,10 +224,8 @@ def do_product(data_set):
     if temp:
         product_out[u'keywords'] = temp
 
-    if in_and_def('lastpublishstatus_en_strs', data_set):
-        result = code_lookup('lastpublishstatus_en_strs', data_set, publish_list)
-        if result:
-            product_out[u'last_publish_status_code'] = result[0]
+    if in_and_def('lastpublishstatuscode_bi_strs', data_set):
+        product_out[u'last_publish_status_code'] = data_set['lastpublishstatuscode_bi_strs']
 
     if in_and_def('legacydate_bi_txts', data_set):
         product_out[u'legacy_date'] = data_set[u'legacydate_bi_txts']

--- a/ckanext/stcndm/schemas/article.yaml
+++ b/ckanext/stcndm/schemas/article.yaml
@@ -18,13 +18,7 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -36,173 +30,82 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: article_create_name
     not_empty unicode name_validator package_name_validator
-  label:
-    en: Internal Unique ID
-    fr: ID interne unique
-  form_snippet: null
 
 - field_name: product_type_code
-  preset: ndm_product
-
-- field_name: related_products
   label:
-    en: Related Products
-    fr: Produits reliés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
-
-- field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
-
-- field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
+    en: Product Type
+    fr: Type de produit
+  preset: select
+  choices:
+    - label:
+        en: Analytical Product
+        fr: Produit Analytique
+      value: '20'
+  required: true
+  schema_field_type: code
   schema_multivalued: false
   schema_extras: true
+
+- field_name: related_products
+  preset: ndm_related_products
+
+- field_name: thesaurus_terms
+  preset: ndm_thesaurus_terms
+
+- field_name: feature_weight
+  preset: ndm_feature_weight
 
 - field_name: archive_status_code
   preset: ndm_archive_status
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: correction_id_code
-  label:
-    en: Correction ID Code
-    fr: Code ID de correction
-  preset: shortcode_multivalue
-  lookup: correction
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_correction_id_code
 
 #- field_name: display_code
 #  preset: ndm_display
 
 - field_name: digital_object_identifier
-  label:
-    en: Digital Object Identifier
-    fr: Identificateur d'objet numérique
-  preset: fluent_text
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_digital_object_identifier
 
 - field_name: external_authors
-  label:
-    en: External Authors
-    fr: Auteurs externes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: internal_authors
-  label:
-    en: Internal Authors
-    fr: Auteurs internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_authors
 
 - field_name: isbn_number
-  label:
-    en: ISBN Number
-    fr: Numéro ISBN
-  preset: fluent_text
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_isbn_number
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
@@ -215,12 +118,7 @@ dataset_fields:
 #  schema_field_type: date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 #- field_name: price
 #  label:
@@ -234,34 +132,21 @@ dataset_fields:
 #  preset: fluent_text
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_old
 
 - field_name: publication_year
-  label:
-    en: Publication Year
-    fr: Année de publication
+  preset: ndm_publication_year
 
-- field_name: reference_periods
-  label:
-    en: Reference Period
-    fr: Période de référence
-  preset: fluent_tags
-  tag_validators: ndm_tag_name_validator tag_length_validator
+#- field_name: reference_periods
+#  label:
+#    en: Reference Period
+#    fr: Période de référence
+#  preset: fluent_tags
+#  tag_validators: ndm_tag_name_validator tag_length_validator
 
 #- field_name: replaced_products
 #  label:
@@ -273,30 +158,16 @@ dataset_fields:
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 #- field_name: subjectold_code
 #  label:

--- a/ckanext/stcndm/schemas/codeset.yaml
+++ b/ckanext/stcndm/schemas/codeset.yaml
@@ -18,17 +18,17 @@ lookup_key: codeset_value
 
 dataset_fields:
 
+- field_name: owner_org
+  preset: ndm_owner_org
+
+- field_name: title  # codeset label
+  preset: ndm_title
+
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation validator with default package name validators
   validators: codeset_create_name
     not_empty unicode name_validator package_name_validator
-  label:
-    en: Internal Unique ID
-    fr: ID interne unique
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: codeset_type
   label:
@@ -48,10 +48,6 @@ dataset_fields:
         en: Geolevel
         fr: Geolevel
       value: 'geolevel'
-#    - label:
-#        en: Dimension Group
-#        fr: Groupe de dimension
-#      value: 'dimension_group'
   required: true
   schema_field_type: code
   schema_multivalued: false
@@ -65,23 +61,3 @@ dataset_fields:
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true
-
-- field_name: title  # codeset label
-  label:
-    en: Descriptive label
-    fr: Étiquette descriptive
-  preset: fluent_text
-  required: true
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
-
-- field_name: owner_org
-  label:
-    en: Organisation
-    fr: Organisation
-  preset: dataset_organization
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false

--- a/ckanext/stcndm/schemas/conference.yaml
+++ b/ckanext/stcndm/schemas/conference.yaml
@@ -17,16 +17,7 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -38,88 +29,49 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: conference_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_type_code
-  preset: ndm_product
+  label:
+    en: Product Type
+    fr: Type de produit
+  preset: select
+  choices:
+    - label:
+        en: Conference
+        fr: Conférence
+      value: '22'
+  required: true
+  schema_field_type: code
+  schema_multivalued: false
+  schema_extras: true
 
 - field_name: related_products
-  label:
-    en: Related
-    fr: Relié
-  preset: repeating_text
-  form_blanks: 3
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -128,13 +80,7 @@ dataset_fields:
   preset: ndm_tracking
 
 - field_name: digital_object_identifier
-  label:
-    en: Digital Object Identifier
-    fr: Identificateur d'objet numérique
-  preset: fluent_text
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_digital_object_identifier
 
 - field_name: array_terminated_code
   preset: ndm_array_terminated
@@ -145,182 +91,80 @@ dataset_fields:
 #    fr: ID de vue par défaut
 
 - field_name: dimension_members
-  label:
-    en: Dimension Member
-    fr: Membre de dimension
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_dimension_members
 
 - field_name: external_authors
-  label:
-    en: External Author
-    fr: Auteur externe
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Source
-    fr: Source
-  preset: shortcode_multivalue
-  lookup: survey
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_survey_source_codes
 
 - field_name: internal_authors
-  label:
-    en: Internal Author
-    fr: Auteur interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_authors
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contact Name
-    fr: Nom de personne ressource interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
 
 - field_name: legacy_date
-  label:
-    en: Legacy Date
-    fr: Date du système antérieur
-  preset: date
-  schema_field_type: date
+  preset: ndm_legacy_date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 - field_name: price
-  label:
-    en: Price
-    fr: Prix
+  preset: ndm_price
 
 - field_name: price_note
-  label:
-    en: Price Note
-    fr: Note sur le prix
-  preset: fluent_text
+  preset: ndm_price_note
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: True
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
+  preset: ndm_product_id_old
 
 - field_name: publication_year
-  label:
-    en: Publication Year
-    fr: Année de publication
+  preset: ndm_publication_year
 
-- field_name: reference_periods
-  label:
-    en: Reference Period
-    fr: Période de référence
-  preset: fluent_tags
-  tag_validators: ndm_tag_name_validator tag_length_validator
+#- field_name: reference_periods
+#  label:
+#    en: Reference Period
+#    fr: Période de référence
+#  preset: fluent_tags
+#  tag_validators: ndm_tag_name_validator tag_length_validator
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 - field_name: subjectold_codes
-  label:
-    en: Old subject
-    fr: Ancien sujet
-  preset: shortcode_multivalue
+  preset: ndm_subjectold_codes

--- a/ckanext/stcndm/schemas/cube.yaml
+++ b/ckanext/stcndm/schemas/cube.yaml
@@ -18,41 +18,13 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
-
-#- field_name: owner_org
-#  label:
-#    en: Organization
-#    fr: Organisation
-#  create_validators: default_from_placeholder
-#  form_attrs:
-#      disabled: disabled
-#  form_placeholder: statcan
-#  schema_field_type: string
-#  schema_multivalued: false
-#  schema_extras: false
-
-#- field_name: private
-#  preset: ndm_visibility
+  preset: ndm_owner_org
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: cube_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -64,43 +36,19 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: tracking_codes
   preset: ndm_tracking
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
-  schema_extras: true
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geodescriptors
-    fr: Géodescriptors
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 #- field_name: format_code
 #  preset: ndm_format
@@ -121,23 +69,10 @@ dataset_fields:
   schema_extras: true
 
 - field_name: related_products
-  label:
-    en: Related Products
-    fr: Produits reliés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_extras: true
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 #- field_name: feature_weight
 #  label:
@@ -145,13 +80,7 @@ dataset_fields:
 #    fr: Poids
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -167,22 +96,8 @@ dataset_fields:
   schema_multivalued: false
   schema_extras: true
 
-#- field_name: dimension_group_codes
-#  label:
-#    en: Dimension Group
-#    fr: Groupe de dimension
-#  preset: codeset_multiple_select
-#  codeset_type: dimension_group
-
 - field_name: dimension_members
-  label:
-    en: Dimension Member
-    fr: Membre de dimension
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_dimension_members
 
 #- field_name: display_code
 #  preset: ndm_display
@@ -193,39 +108,16 @@ dataset_fields:
 #    fr: Auteur externe
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Survey Source
-    fr: Source de songage
-  preset: shortcode_multivalue
-  lookup: survey
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_survey_source_codes
 
 #- field_name: internal_author
 #  label:
@@ -233,24 +125,10 @@ dataset_fields:
 #    fr: Auteur interne
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contact Name
-    fr: Nom de personne ressource interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
@@ -263,12 +141,7 @@ dataset_fields:
 #  schema_field_type: date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 #- field_name: price
 #  label:
@@ -282,20 +155,10 @@ dataset_fields:
 #  preset: fluent_text
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_product_id_old
 
 #- field_name: publication_year
 #  label:
@@ -322,43 +185,22 @@ dataset_fields:
 #  schema_extras: true
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 #- field_name: subjectold_code
 #  label:
@@ -367,14 +209,7 @@ dataset_fields:
 #  preset: shortcode_multivalue
 
 - field_name: url
-  label:
-    en: URL
-    fr: URL
-  preset: fluent_text
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
-  display_snippet: url.html
+  preset: ndm_url
 
 #- field_name: volume_and_number
 #  label:

--- a/ckanext/stcndm/schemas/daily.yaml
+++ b/ckanext/stcndm/schemas/daily.yaml
@@ -16,26 +16,10 @@ languages_label:
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: name
-  # follow our custom name generation with default package name validators
-  validators: daily_create_name
-    not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_name
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -47,43 +31,19 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: tracking_codes
   preset: ndm_tracking
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
-  schema_extras: true
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geodescriptors
-    fr: Géodescriptors
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 #- field_name: format_code
 #  preset: ndm_format
@@ -104,23 +64,10 @@ dataset_fields:
   schema_extras: true
 
 - field_name: related_products
-  label:
-    en: Related Products
-    fr: Produits reliés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_extras: true
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 #- field_name: feature_weight
 #  label:
@@ -128,13 +75,7 @@ dataset_fields:
 #    fr: Poids
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -154,22 +95,10 @@ dataset_fields:
 #  preset: ndm_display
 
 - field_name: external_authors
-  label:
-    en: External Author
-    fr: Auteur externe
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 #- field_name: frequency_codes
 #  label:
@@ -180,61 +109,25 @@ dataset_fields:
 #  schema_extras: true
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_history_notes
 
-- field_name: internal_author
-  label:
-    en: Internal Author
-    fr: Auteur interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+- field_name: internal_authors
+  preset: ndm_internal_authors
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contact Name
-    fr: Nom de personne ressource interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
 
 - field_name: legacy_date
-  label:
-    en: Legacy Date
-    fr: Date du système antérieur
-  preset: date
-  schema_field_type: date
+  preset: ndm_legacy_date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 #- field_name: price
 #  label:
@@ -248,20 +141,10 @@ dataset_fields:
 #  preset: fluent_text
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_product_id_old
 
 #- field_name: publication_year
 #  label:
@@ -288,43 +171,22 @@ dataset_fields:
 #  schema_extras: true
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 #- field_name: subjectold_code
 #  label:

--- a/ckanext/stcndm/schemas/format.yaml
+++ b/ckanext/stcndm/schemas/format.yaml
@@ -16,14 +16,7 @@ languages_label:
 dataset_fields:
 
 - field_name: owner_org
-  label:
-    en: Organisation
-    fr: Organisation
-  preset: dataset_organization
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: release_slug
   label:
@@ -35,12 +28,7 @@ dataset_fields:
   schema_extras: true
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 - field_name: parent_id
   label:
@@ -55,26 +43,13 @@ dataset_fields:
   required: true
 
 - field_name: url
-  label:
-    en: URL
-    fr: URL
-  preset: fluent_text
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: true
-  display_snippet: url.html
+  preset: ndm_url
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation validator with default package name validators
   validators: format_create_name
     not_empty unicode name_validator package_name_validator
-  label:
-    en: Dataset Slug
-    fr: Slug du dataset
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: title
   validators: format_create_name
@@ -91,10 +66,3 @@ dataset_fields:
   schema_field_type: fluent
   schema_multivalued: false
   schema_extras: true
-
-- field_name: bogon
-  label:
-    en: Bogon
-    fr: Bogon
-  create_validators: set_default_value(statcan)
-  default_value: statcan

--- a/ckanext/stcndm/schemas/geodescriptor.yaml
+++ b/ckanext/stcndm/schemas/geodescriptor.yaml
@@ -18,54 +18,22 @@ lookup_key: geodescriptor_code
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation validator with default package name validators
   validators: geodescriptor_create_name
     not_empty unicode name_validator package_name_validator
-  label:
-    en: Internal Unique ID
-    fr: ID interne unique
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_id_old # 10uid_bi_strs
-  label:
-    en: Product ID Old
-    fr: Ancien ID du produit
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_product_id_old
 
 - field_name: title # tmsgcname_en_tmtxtm tmsgcname_fr_tmtxtm
-  label:
-    en: Title
-    fr: Titre
-  preset: fluent_text
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_title
 
 - field_name: geolevel_codes # tmsgccode_bi_tmtxtm
-  label:
-    en: Geolevel Code
-    fr: Code geolevel
-  required: true
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_code # tmsgcspecificcode_bi_tmtxtm
   label:

--- a/ckanext/stcndm/schemas/indicator.yaml
+++ b/ckanext/stcndm/schemas/indicator.yaml
@@ -18,13 +18,7 @@ lookup_code: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
+  preset: ndm_owner_org
 
 - field_name: calculations
   label:
@@ -54,30 +48,13 @@ dataset_fields:
   schema_extras: true
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: ndm_states
   label:
@@ -88,22 +65,10 @@ dataset_fields:
   schema_extras: true
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: table_ids
   label:
@@ -117,14 +82,10 @@ dataset_fields:
   preset: ndm_title
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: indicator_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_type_code
   label:

--- a/ckanext/stcndm/schemas/presets.yaml
+++ b/ckanext/stcndm/schemas/presets.yaml
@@ -4,26 +4,6 @@ about_url:
 
 presets:
 
-- preset_name: codeset_multiple_select
-  values:
-    schema_field_type: code
-    schema_multivalued: true
-    schema_extras: true
-    form_snippet: codeset_multiple_select.html
-    display_snippet: codeset_multiple_choice.html
-    validators: ignore_missing codeset_multiple_choice
-    output_validators: scheming_multiple_choice_output
-    lookup: codeset
-
-- preset_name: codeset_select
-  values:
-    schema_field_type: code
-    schema_multivalued: false
-    form_snippet: codeset_select.html
-    display_snippet: select.html
-    validators: scheming_required scheming_choices
-    lookup: codeset
-
 - preset_name: ndm_admin_notes
   values:
     label:
@@ -40,6 +20,18 @@ presets:
     error_snippet: fluent_text.html
     validators: fluent_text
     output_validators: fluent_text_output
+
+- preset_name: ndm_archive_date
+  values:
+    label:
+      en: Archive Date
+      fr: Date d'archivage
+    form_snippet: date.html
+    display_snippet: date.html
+    validators: scheming_required isodate
+    schema_field_type: date
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_archive_status
   values:
@@ -149,6 +141,26 @@ presets:
     schema_multivalued: false
     schema_extras: true
 
+- preset_name: ndm_codeset_multiple_select
+  values:
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+    form_snippet: codeset_multiple_select.html
+    display_snippet: codeset_multiple_choice.html
+    validators: ignore_missing codeset_multiple_choice
+    output_validators: scheming_multiple_choice_output
+    lookup: codeset
+
+- preset_name: ndm_codeset_select
+  values:
+    schema_field_type: code
+    schema_multivalued: false
+    form_snippet: codeset_select.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+    lookup: codeset
+
 - preset_name: ndm_collection_methods
   values:
     label:
@@ -228,6 +240,21 @@ presets:
             fr: Interview téléphonique (sans ordinateur)
         value: '25'
 
+- preset_name: ndm_content_type_codes
+  values:
+    label:
+      en: Content Type
+      fr: Type de contenu
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+    form_snippet: codeset_multiple_select.html
+    display_snippet: codeset_multiple_choice.html
+    validators: ignore_missing codeset_multiple_choice
+    output_validators: scheming_multiple_choice_output
+    lookup: codeset
+    codeset_type: content_type
+
 - preset_name: ndm_correction_impact_level
   values:
     label:
@@ -249,6 +276,19 @@ presets:
           en: High
           fr: Haut
         value: '1'
+
+- preset_name: ndm_correction_id_code
+  values:
+    label:
+      en: Correction ID Code
+      fr: Code ID de correction
+    form_snippet: shortcode_multivalue.html
+    display_snippet: shortcode_multivalue.html
+    validators: shortcode_validate
+    output_validators: shortcode_output
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_correction_type
   values:
@@ -319,6 +359,72 @@ presets:
     validators: fluent_text
     output_validators: fluent_text_output
 
+- preset_name: ndm_digital_object_identifier
+  values:
+    label:
+      en: Digital Object Identifier
+      fr: Identificateur d'objet numérique
+    form_snippet: fluent_text.html
+    display_snippet: fluent_text.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_text_output
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_discontinued_code
+  values:
+    label:
+      en: Discontinued/Not Available
+      fr: Discontinué/Non Disponible
+    choices:
+      - label:
+          en: 'False'
+          fr: 'Faux'
+        value: '0'
+      - label:
+          en: 'True'
+          fr: 'Vrai'
+        value: '1'
+    form_snippet: select.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+    lookup: preset
+    schema_field_type: code
+    schema_multivalue: false
+    schema_extras: true
+
+- preset_name: ndm_dimension_members
+  values:
+    label:
+      en: Dimension Members
+      fr: Membres de dimension
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator tag_length_validator
+    form_attrs:
+      data-module: autocomplete
+      data-module-tags:
+    schema_field_type: fluent
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_discontinued_date
+  values:
+    label:
+      en: Discontinued Date
+      fr: Date discontinué
+    form_snippet: date.html
+    display_snippet: date.html
+    validators: scheming_required isodate
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
+
 - preset_name: ndm_display
   values:
     label:
@@ -344,6 +450,29 @@ presets:
           en: Hide navigation link
           fr: Masquer le lien de navigation
         value: '3'
+
+- preset_name: ndm_external_authors
+  values:
+    label:
+      en: External Authors
+      fr: Auteurs externes
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    form_blanks: 3
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_feature_weight
+  values:
+    label:
+      en: Feature Weight
+      fr: Poids
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_format
   values:
@@ -411,6 +540,133 @@ presets:
             fr: ETF
         value: '19'
 
+- preset_name: ndm_frc
+  values:
+    label:
+      en: FRC
+      fr: FRC
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_frequency_codes
+  values:
+    label:
+      en: Frequency
+      fr: Fréquence
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+    form_snippet: codeset_multiple_select.html
+    display_snippet: codeset_multiple_choice.html
+    validators: ignore_missing codeset_multiple_choice
+    output_validators: scheming_multiple_choice_output
+    lookup: codeset
+    codeset_type: frequency
+
+- preset_name: ndm_geodescriptor_codes
+  values:
+    label:
+      en: Geo Specific
+      fr: Géo spécifique
+    form_snippet: shortcode_multivalue.html
+    display_snippet: shortcode_multivalue.html
+    validators: shortcode_validate
+    output_validators: shortcode_output
+    lookup: geodescriptor
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_geolevel_codes
+  values:
+    label:
+      en: Geolevel
+      fr: Geolevel
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+    form_snippet: codeset_multiple_select.html
+    display_snippet: codeset_multiple_choice.html
+    validators: ignore_missing codeset_multiple_choice
+    output_validators: scheming_multiple_choice_output
+    lookup: codeset
+    codeset_type: geolevel
+
+- preset_name: ndm_history_notes
+  values:
+    label:
+      en: History Notes
+      fr: Notes historiques
+    form_snippet: fluent_markdown.html
+    display_snippet: fluent_markdown.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_internal_authors
+  values:
+    label:
+      en: Internal Authors
+      fr: Auteurs internes
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    form_blanks: 3
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_internal_contacts
+  values:
+    label:
+      en: Internal Contact Names
+      fr: Nom de personnes ressource internes
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    form_blanks: 3
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_isbn_number
+  values:
+    label:
+      en: ISBN Number
+      fr: Numéro ISBN
+    form_snippet: fluent_text.html
+    display_snippet: fluent_text.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_keywords
+  values:
+    label:
+      en: Keywords
+      fr: Mots clés
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator tag_length_validator
+    form_attrs:
+      data-module: autocomplete
+      data-module-tags:
+    schema_field_type: fluent
+    schema_multivalued: true
+    schema_extras: true
+
 - preset_name: ndm_language
   values:
     label:
@@ -433,41 +689,87 @@ presets:
         fr: Francais
       value: 'fr'
 
+- preset_name: ndm_legacy_date
+  values:
+    label:
+      en: Legacy Date
+      fr: Date du système antérieur
+    form_snippet: date.html
+    display_snippet: date.html
+    validators: scheming_required isodate
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_load_to_olc_code
+  values:
+    label:
+      en: Load to OLC
+      fr: Charger au OLC
+    choices:
+      - label:
+          en: 'False'
+          fr: 'Faux'
+        value: '0'
+      - label:
+          en: 'True'
+          fr: 'Vrai'
+        value: '1'
+    form_snippet: select.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+    lookup: preset
+    schema_field_type: code
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_name
+  values:
+    label:
+      en: Internal Unique ID
+      fr: ID interne unique
+    form_snippet: null
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: false
+
 - preset_name: ndm_owner_org
   values:
     label:
       en: Organization
       fr: Organisation
-    create_validators: default_value
+#    create_validators: default_value
     form_attrs:
         disabled: disabled
     form_placeholder: statcan
     schema_field_type: string
     schema_multivalued: false
     schema_extras: false
+    validators: owner_org_validator unicode
+    form_snippet: organization.html
 
-- preset_name: ndm_visibility
+- preset_name: ndm_price
   values:
     label:
-      en: Visibility
-      fr: Visibilité
-    form_snippet: select.html
-    display_snippet: select.html
-    validators: scheming_required scheming_choices
-    lookup: preset
-    required: true
-    schema_field_type: boolean
+      en: Price
+      fr: Prix
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_price_note
+  values:
+    label:
+      en: Price Note
+      fr: Note sur le prix
+    form_snippet: fluent_text.html
+    display_snippet: fluent_text.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_text_output
+    schema_field_type: fluent
     schema_multivalued: false
-    schema_extras: false
-    choices:
-    - label:
-        en: Public
-        fr: Publique
-      value: false
-    - label:
-        en: Private
-        fr: Privé
-      value: true
+    schema_extras: true
 
 - preset_name: ndm_product
   values:
@@ -530,6 +832,34 @@ presets:
           en: Publications with repeating titles (Generic)
           fr: Publications avec des titres répétitifs (générique)
         value: '26'
+
+- preset_name: ndm_product_id_new
+  values:
+    label:
+      en: Product ID New
+      fr: ID produit nouveau
+    required: true
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_product_id_old
+  values:
+    label:
+      en: Product ID Old
+      fr: ID produit ancien
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
+
+- preset_name: ndm_publication_year
+  values:
+    label:
+      en: Publication Year
+      fr: Année de publication
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_publish_status
   values:
@@ -597,6 +927,43 @@ presets:
           fr: Figé
         value: '99'
 
+- preset_name: ndm_related_products
+  values:
+    label:
+      en: Related Products
+      fr: Produits reliés
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    form_blanks: 3
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_replaced_products
+  values:
+    label:
+      en: Replaced Products
+      fr: Produits remplacés
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    form_blanks: 3
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_shortcode_multivalue
+  values:
+    form_snippet: shortcode_multivalue.html
+    display_snippet: shortcode_multivalue.html
+    validators: shortcode_validate
+    output_validators: shortcode_output
+    schema_field_type: code
+    schema_multivalued: true
+
 - preset_name: ndm_status
   values:
     label:
@@ -658,6 +1025,33 @@ presets:
           fr: Dernier numéro completé
           en: Last completed issue
         value: '90'
+
+- preset_name: ndm_subject_codes
+  values:
+    label:
+      en: Subject
+      fr: Sujet
+    form_snippet: shortcode_multivalue.html
+    display_snippet: shortcode_multivalue.html
+    validators: shortcode_validate
+    output_validators: shortcode_output
+    lookup: subject
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+
+- preset_name: ndm_subjectold_codes
+  values:
+    label:
+      en: Old subjects
+      fr: Anciens sujets
+    form_snippet: repeating_text.html
+    display_snippet: repeating_text.html
+    validators: repeating_text
+    output_validators: repeating_text_output
+    schema_field_type: string
+    schema_multivalued: true
+    schema_extras: true
 
 - preset_name: ndm_subject_display
   values:
@@ -849,6 +1243,20 @@ presets:
           fr: Tourisme et le Centre de la statistique de l'éducation (DTCSE)
         value: '28'
 
+- preset_name: ndm_survey_source_codes
+  values:
+    label:
+      en: Source
+      fr: Source
+    form_snippet: shortcode_multivalue.html
+    display_snippet: shortcode_multivalue.html
+    validators: shortcode_validate
+    output_validators: shortcode_output
+    lookup: survey
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+
 - preset_name: ndm_survey_status
   values:
     label:
@@ -871,6 +1279,24 @@ presets:
           fr: Inactif
         value: '2'
 
+- preset_name: ndm_thesaurus_terms
+  values:
+    label:
+      en: STC Thesaurus Terms
+      fr: Dictionnaire de synonymes de STC
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator tag_length_validator
+    form_attrs:
+      data-module: autocomplete
+      data-module-tags: ""
+    schema_field_type: fluent
+    schema_multivalued: true
+    schema_extras: true
+
 - preset_name: ndm_title
   values:
     label:
@@ -887,6 +1313,15 @@ presets:
     error_snippet: fluent_text.html
     validators: fluent_text
     output_validators: fluent_text_output
+
+- preset_name: ndm_top_parent_id
+  values:
+    label:
+      en: Top Parent ID
+      fr: ID du parent du plus haut niveau
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_tracking
   values:
@@ -979,11 +1414,48 @@ presets:
             fr: En attente - rgtabv
         value: '19'
 
-- preset_name: shortcode_multivalue
+- preset_name: ndm_url
   values:
-    form_snippet: shortcode_multivalue.html
-    display_snippet: shortcode_multivalue.html
-    validators: shortcode_validate
-    output_validators: shortcode_output
-    schema_field_type: code
-    schema_multivalued: true
+    label:
+      en: URL
+      fr: URL
+    form_snippet: fluent_text.html
+    display_snippet: fluent_text.html url.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: false
+
+- preset_name: ndm_visibility
+  values:
+    label:
+      en: Visibility
+      fr: Visibilité
+    form_snippet: select.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+    lookup: preset
+    required: true
+    schema_field_type: boolean
+    schema_multivalued: false
+    schema_extras: false
+    choices:
+    - label:
+        en: Public
+        fr: Publique
+      value: false
+    - label:
+        en: Private
+        fr: Privé
+      value: true
+
+- preset_name: ndm_volume_and_number
+  values:
+    label:
+      en: Volume and Number
+      fr: Volume et nombre
+    schema_field_type: string
+    schema_multivalued: false
+    schema_extras: true

--- a/ckanext/stcndm/schemas/province.yaml
+++ b/ckanext/stcndm/schemas/province.yaml
@@ -18,35 +18,16 @@ lookup_key: sgc_code
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: province_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: title  # codeset label
-  label:
-    en: Descriptive label
-    fr: Étiquette descriptive
-  preset: fluent_text
-  required: true
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_title
 
 - field_name: geotype
   label:

--- a/ckanext/stcndm/schemas/publication.yaml
+++ b/ckanext/stcndm/schemas/publication.yaml
@@ -18,16 +18,7 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -39,91 +30,49 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators:  publication_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_type_code
-  preset: ndm_product
+  label:
+    en: Product Type
+    fr: Type de produit
+  preset: select
+  choices:
+    - label:
+        en: Analytical Product
+        fr: Produit Analytique
+      value: '20'
+  required: true
 
 - field_name: related_products
-  label:
-    en: Related
-    fr: Relié
-  preset: repeating_text
-  form_blanks: 3
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: archive_status_code
   preset: ndm_archive_status
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 #- field_name: display_code
 #  preset: ndm_display
@@ -132,13 +81,7 @@ dataset_fields:
   preset: ndm_tracking
 
 - field_name: digital_object_identifier
-  label:
-    en: Digital Object Identifier
-    fr: Identificateur d'objet numérique
-  preset: fluent_text
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_digital_object_identifier
 
 #- field_name: array_terminated_code
 #  preset: ndm_array_terminated
@@ -155,75 +98,28 @@ dataset_fields:
 #  preset: shortcode_multivalue
 
 - field_name: external_authors
-  label:
-    en: External Authors
-    fr: Auteurs externes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Source
-    fr: Source
-  preset: shortcode_multivalue
-  lookup: survey
+  preset: ndm_survey_source_codes
 
 - field_name: internal_authors
-  label:
-    en: Internal Authors
-    fr: Auteurs internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_authors
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contacts
-    fr: Personnes ressource internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
@@ -236,12 +132,7 @@ dataset_fields:
 #  schema_field_type: date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 #- field_name: price
 #  label:
@@ -255,20 +146,13 @@ dataset_fields:
 #  preset: fluent_text
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: True
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
+  preset: ndm_product_id_old
 
 - field_name: publication_year
-  label:
-    en: Publication Year
-    fr: Année de publication
+  preset: ndm_publication_year
 
 #- field_name: reference_periods
 #  label:
@@ -278,50 +162,25 @@ dataset_fields:
 #  tag_validators: ndm_tag_name_validator tag_length_validator
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 - field_name: subjectold_codes
-  label:
-    en: Old subject
-    fr: Ancien sujet
-  preset: repeating_text
-  form_blanks: 3
+  preset: ndm_subjectold_codes
 
 #- field_name: volume_and_number
 #  label:

--- a/ckanext/stcndm/schemas/pumf.yaml
+++ b/ckanext/stcndm/schemas/pumf.yaml
@@ -18,16 +18,7 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -39,88 +30,46 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: pumf_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_type_code
-  preset: ndm_product
+  label:
+    en: Product Type
+    fr: Type de produit
+  preset: select
+  choices:
+    - label:
+        en: PUMF
+        fr: PUMF
+      value: '25'
+  required: true
 
 - field_name: related_products
-  label:
-    en: Related
-    fr: Relié
-  preset: repeating_text
-  form_blanks: 3
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -129,13 +78,7 @@ dataset_fields:
   preset: ndm_tracking
 
 - field_name: digital_object_identifier
-  label:
-    en: Digital Object Identifier
-    fr: Identificateur d'objet numérique
-  preset: fluent_text
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_digital_object_identifier
 
 - field_name: array_terminated_code
   preset: ndm_array_terminated
@@ -146,183 +89,80 @@ dataset_fields:
 #    fr: ID de vue par défaut
 
 - field_name: dimension_members
-  label:
-    en: Dimension Member
-    fr: Membre de dimension
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_dimension_members
 
 - field_name: external_authors
-  label:
-    en: External Author
-    fr: Auteur externe
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Source
-    fr: Source
-  preset: shortcode_multivalue
-  lookup: survey
+  preset: ndm_survey_source_codes
 
 - field_name: internal_authors
-  label:
-    en: Internal Authors
-    fr: Auteurs internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_authors
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contacts
-    fr: Personnes ressource internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
 
 - field_name: legacy_date
-  label:
-    en: Legacy Date
-    fr: Date du système antérieur
-  preset: date
-  schema_field_type: date
+  preset: ndm_legacy_date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 - field_name: price
-  label:
-    en: Price
-    fr: Prix
+  preset: ndm_price
 
 - field_name: price_note
-  label:
-    en: Price Note
-    fr: Note sur le prix
-  preset: fluent_text
+  preset: ndm_price_note
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: True
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
+  preset: ndm_product_id_old
 
 - field_name: publication_year
-  label:
-    en: Publication Year
-    fr: Année de publication
+  preset: ndm_publication_year
 
-- field_name: reference_periods
-  label:
-    en: Reference Period
-    fr: Période de référence
-  preset: fluent_tags
-  tag_validators: ndm_tag_name_validator tag_length_validator
+#- field_name: reference_periods
+#  label:
+#    en: Reference Period
+#    fr: Période de référence
+#  preset: fluent_tags
+#  tag_validators: ndm_tag_name_validator tag_length_validator
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 - field_name: subjectold_codes
-  label:
-    en: Old subject
-    fr: Ancien sujet
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subjectold_codes

--- a/ckanext/stcndm/schemas/release.yaml
+++ b/ckanext/stcndm/schemas/release.yaml
@@ -16,14 +16,7 @@ languages_label:
 dataset_fields:
 
 - field_name: owner_org
-  label:
-    en: Organisation
-    fr: Organisation
-  preset: dataset_organization
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: release_date
   label:
@@ -67,13 +60,7 @@ dataset_fields:
   schema_extras: true
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent Product ID
-    fr: ID du produit parent de plus haut niveau
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 - field_name: publish_status_code
   preset: ndm_publish_status
@@ -104,16 +91,10 @@ dataset_fields:
       value: '1'
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation validator with default package name validators
   validators: release_create_name
     not_empty unicode package_name_validator
-  label:
-    en: Dataset Slug
-    fr: Slug du dataset
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: title
   validators: release_create_name
@@ -131,4 +112,3 @@ dataset_fields:
   schema_extras: true
   form_attrs:
       disabled: disabled
-

--- a/ckanext/stcndm/schemas/service.yaml
+++ b/ckanext/stcndm/schemas/service.yaml
@@ -17,16 +17,7 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -38,91 +29,46 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: service_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_type_code
-  preset: ndm_product
+  label:
+    en: Product Type
+    fr: Type de produit
+  preset: select
+  choices:
+    - label:
+        en: Service
+        fr: Service
+      value: '23'
+  required: true
 
 - field_name: related_products
-  label:
-    en: Related
-    fr: Relié
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -131,13 +77,7 @@ dataset_fields:
   preset: ndm_tracking
 
 - field_name: digital_object_identifier
-  label:
-    en: Digital Object Identifier
-    fr: Identificateur d'objet numérique
-  preset: fluent_text
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_digital_object_identifier
 
 - field_name: array_terminated_code
   preset: ndm_array_terminated
@@ -148,183 +88,80 @@ dataset_fields:
 #    fr: ID de vue par défaut
 
 - field_name: dimension_members
-  label:
-    en: Dimension Member
-    fr: Membre de dimension
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_dimension_members
 
 - field_name: external_authors
-  label:
-    en: External Authors
-    fr: Auteurs externes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Source
-    fr: Source
-  preset: shortcode_multivalue
-  lookup: survey
+  preset: ndm_survey_source_codes
 
 - field_name: internal_authors
-  label:
-    en: Internal Authors
-    fr: Auteurs internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_authors
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contacts
-    fr: Personnes ressource internes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
 
 - field_name: legacy_date
-  label:
-    en: Legacy Date
-    fr: Date du système antérieur
-  preset: date
-  schema_field_type: date
+  preset: ndm_legacy_date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 - field_name: price
-  label:
-    en: Price
-    fr: Prix
+  preset: ndm_price
 
 - field_name: price_note
-  label:
-    en: Price Note
-    fr: Note sur le prix
-  preset: fluent_text
+  preset: ndm_price_note
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: True
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
+  preset: ndm_product_id_old
 
 - field_name: publication_year
-  label:
-    en: Publication Year
-    fr: Année de publication
+  preset: ndm_publication_year
 
-- field_name: reference_periods
-  label:
-    en: Reference Period
-    fr: Période de référence
-  preset: fluent_tags
-  tag_validators: ndm_tag_name_validator tag_length_validator
+#- field_name: reference_periods
+#  label:
+#    en: Reference Period
+#    fr: Période de référence
+#  preset: fluent_tags
+#  tag_validators: ndm_tag_name_validator tag_length_validator
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 - field_name: subjectold_codes
-  label:
-    en: Old subject
-    fr: Ancien sujet
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subjectold_codes

--- a/ckanext/stcndm/schemas/subject.yaml
+++ b/ckanext/stcndm/schemas/subject.yaml
@@ -18,47 +18,19 @@ lookup_key: subject_code
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: subject_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: title  # codeset label
-  label:
-    en: Descriptive label
-    fr: Étiquette descriptive
-  preset: fluent_text
-  required: true
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_title
 
 - field_name: admin_notes
-  form_placeholder:
-    en: Admin Notes
-    fr: Notes
-  label:
-    en: Admin Notes
-    fr: Notes
-  preset: fluent_markdown
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_admin_notes
 
 - field_name : a_to_z_alias
   label:
@@ -89,12 +61,5 @@ dataset_fields:
   schema_extras: true
 
 - field_name: subjectold_codes
-  label:
-    en: Old Subject Code
-    fr: Ancien code du sujet
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subjectold_codes
 

--- a/ckanext/stcndm/schemas/survey.yaml
+++ b/ckanext/stcndm/schemas/survey.yaml
@@ -19,44 +19,19 @@ lookup_key: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  label:
-    en: Organisation
-    fr: Organisation
-  preset: dataset_organization
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
+  preset: ndm_owner_org
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation validator with default package name validators
   validators: survey_create_name
     not_empty unicode name_validator package_name_validator
-  label:
-    en: Internal Unique ID
-    fr: ID interne unique
-  form_snippet: null
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 - field_name: archive_status_code
   preset: ndm_archive_status
@@ -83,38 +58,19 @@ dataset_fields:
   schema_extras: true
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
+  preset: ndm_content_type_codes
 
 - field_name: notes
   preset: ndm_description
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
-  schema_field_type: int
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_feature_weight
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: survey_instance_item
   label:
@@ -142,14 +98,7 @@ dataset_fields:
   schema_extras: true
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_keywords
 
 - field_name: question_url
   label:
@@ -196,24 +145,10 @@ dataset_fields:
   preset: ndm_survey_status
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: survey_url
   label:
@@ -235,11 +170,4 @@ dataset_fields:
   preset: ndm_title
 
 - field_name: url
-  label:
-    en: URL
-    fr: URL
-  preset: fluent_text
-  schema_field_type: fluent
-  schema_multivalued: false
-  schema_extras: false
-  display_snippet: url.html
+  preset: ndm_url

--- a/ckanext/stcndm/schemas/view.yaml
+++ b/ckanext/stcndm/schemas/view.yaml
@@ -18,13 +18,7 @@ lookup_code: product_id_new
 dataset_fields:
 
 - field_name: owner_org
-  help_text:
-    en: The organization directly responsible for the dataset and for metadata maintenance.
-    fr: Le nom de l’organisation directement responsable des ensembles de donnée et de la maintenance des métadonnées
-  label:
-    en: Publisher
-    fr: Éditeur
-  preset: dataset_organization
+  preset: ndm_owner_org
 
 - field_name: admin_notes
   preset: ndm_admin_notes
@@ -36,54 +30,25 @@ dataset_fields:
   preset: ndm_description
 
 - field_name: content_type_codes
-  label:
-    en: Content Type
-    fr: Type de contenu
-  preset: codeset_multiple_select
-  codeset_type: content_type
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_content_type_codes
 
 - field_name: tracking_codes
   preset: ndm_tracking
 
 - field_name: geolevel_codes
-  label:
-    en: Geolevel
-    fr: Geolevel
-  preset: codeset_multiple_select
-  codeset_type: geolevel
+  preset: ndm_geolevel_codes
 
 - field_name: geodescriptor_codes
-  label:
-    en: Geo Specific
-    fr: Géo spécifique
-  preset: shortcode_multivalue
-  lookup: geodescriptor
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_geodescriptor_codes
 
 - field_name: subject_codes
-  label:
-    en: Subject
-    fr: Sujet
-  preset: shortcode_multivalue
-  lookup: subject
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_subject_codes
 
 - field_name: name
+  preset: ndm_name
   # follow our custom name generation with default package name validators
   validators: view_create_name
     not_empty unicode name_validator package_name_validator
-  form_snippet: null
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: false
 
 #- field_name: format_code
 #  preset: ndm_format
@@ -101,41 +66,19 @@ dataset_fields:
   required: true
 
 - field_name: related_products
-  label:
-    en: Related
-    fr: Relié
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_related_products
 
 - field_name: thesaurus_terms
-  label:
-    en: STC Thesaurus Terms
-    fr: Dictionnaire de synonymes de STC
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_thesaurus_terms
 
 - field_name: feature_weight
-  label:
-    en: Feature Weight
-    fr: Poids
+  preset: ndm_feature_weight
 
 - field_name: archive_status
   preset: ndm_archive_status
 
 - field_name: archive_date
-  label:
-    en: Archive Date
-    fr: Date d'archivage
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_archive_date
 
 #- field_name: array_terminated
 #  label:
@@ -155,56 +98,25 @@ dataset_fields:
 #  lookup: dimension_group
 
 - field_name: dimension_members
-  label:
-    en: Dimension Member
-    fr: Membre de dimension
-  preset: fluent_tags
-  schema_field_type: fluent
-  schema_multivalued: true
-  schema_extras: true
-  tag_validators: ndm_tag_name_validator tag_length_validator
+  preset: ndm_dimension_members
 
 #- field_name: display_code
 #  preset: ndm_display
 
 - field_name: external_authors
-  label:
-    en: External Authors
-    fr: Auteurs externes
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_external_authors
 
 - field_name: frc
-  label:
-    en: FRC
-    fr: FRC
+  preset: ndm_frc
 
 - field_name: frequency_codes
-  label:
-    en: Frequency
-    fr: Fréquence
-  preset: codeset_multiple_select
-  codeset_type: frequency
-  schema_extras: true
+  preset: ndm_frequency_codes
 
 - field_name: history_notes
-  label:
-    en: History Notes
-    fr: Notes historiques
-  preset: fluent_markdown
+  preset: ndm_history_notes
 
 - field_name: survey_source_codes
-  label:
-    en: Source
-    fr: Source
-  preset: shortcode_multivalue
-  lookup: survey
-  schema_field_type: code
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_survey_source_codes
 
 #- field_name: internal_author
 #  label:
@@ -212,20 +124,10 @@ dataset_fields:
 #    fr: Auteur interne
 
 - field_name: internal_contacts
-  label:
-    en: Internal Contact Name
-    fr: Nom de personne ressource interne
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_internal_contacts
 
 - field_name: keywords
-  label:
-    en: Keywords
-    fr: Mots clés
-  preset: fluent_text
+  preset: ndm_keywords
 
 - field_name: last_publish_status_code
   preset: ndm_publish_status
@@ -238,12 +140,7 @@ dataset_fields:
 #  schema_field_type: date
 
 - field_name: top_parent_id
-  label:
-    en: Top Parent ID
-    fr: ID du parent du plus haut niveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_top_parent_id
 
 #- field_name: price
 #  label:
@@ -257,20 +154,10 @@ dataset_fields:
 #  preset: fluent_text
 
 - field_name: product_id_new
-  label:
-    en: Product ID New
-    fr: ID produit nouveau
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_new
 
 - field_name: product_id_old
-  label:
-    en: Product ID Old
-    fr: ID produit ancien
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_product_id_old
 
 #- field_name: publication_year
 #  label:
@@ -291,43 +178,22 @@ dataset_fields:
 #  schema_field_type: date
 
 - field_name: replaced_products
-  label:
-    en: Replaced Products
-    fr: Produits remplacés
-  preset: repeating_text
-  form_blanks: 3
-  schema_field_type: string
-  schema_multivalued: true
-  schema_extras: true
+  preset: ndm_replaced_products
 
 - field_name: status_code
   preset: ndm_status
 
 - field_name: discontinued_code
-  label:
-    en: Discontinued/Not Available
-    fr: Discontinué/Non Disponible
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_discontinued_code
 
 - field_name: discontinued_date
-  label:
-    en: Discontinued Date
-    fr: Date discontinué
-  preset: date
-  schema_field_type: date
-  schema_multivalued: false
-  schema_extras: true
+  preset: ndm_discontinued_date
 
 - field_name: census_grouping_code
   preset: ndm_census_grouping
 
 - field_name: load_to_olc_code
-  label:
-    en: Load to OLC
-    fr: Charger au OLC
-  preset: ndm_boolean
-  schema_extras: true
+  preset: ndm_load_to_olc_code
 
 #- field_name: subjectold_code
 #  label:
@@ -336,13 +202,7 @@ dataset_fields:
 #  preset: shortcode_multivalue
 
 - field_name: url
-  label:
-    en: URL
-    fr: URL
-  preset: fluent_text
-  display_snippet: url.html
+  preset: ndm_url
 
 - field_name: volume_and_number
-  label:
-    en: Volume and Number
-    fr: Volume et nombre
+  preset: ndm_volume_and_number

--- a/ckanext/stcndm/validators.py
+++ b/ckanext/stcndm/validators.py
@@ -138,7 +138,7 @@ def format_create_name(key, data, errors, context):
 
     data[key] = u'format-{0}_{1}'.format(
         parent_id.lower(),
-        format_code.lower()
+        format_code.zfill(2).lower()
     )
 
 


### PR DESCRIPTION
moved alot of the schema to presets.yaml to make individual schemas simpler
and more standardized.  most field declarations just call a preset.  this way
fields that are common to many schemas are defined in presets.yaml
