### PR TITLE
removed required: true from schemas

### DIFF
--- a/ckanext/stcndm/schemas/article.yaml
+++ b/ckanext/stcndm/schemas/article.yaml
@@ -37,7 +37,6 @@ dataset_fields:
 
 - field_name: top_parent_id
   preset: ndm_top_parent_id
-  required: true
 
 - field_name: issue_number
   preset: ndm_issue_number

--- a/ckanext/stcndm/schemas/chart.yaml
+++ b/ckanext/stcndm/schemas/chart.yaml
@@ -33,7 +33,6 @@ dataset_fields:
 
 - field_name: top_parent_id
   preset: ndm_top_parent_id
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/conference.yaml
+++ b/ckanext/stcndm/schemas/conference.yaml
@@ -36,7 +36,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/cube.yaml
+++ b/ckanext/stcndm/schemas/cube.yaml
@@ -37,7 +37,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/daily.yaml
+++ b/ckanext/stcndm/schemas/daily.yaml
@@ -35,7 +35,6 @@ dataset_fields:
 
 - field_name: product_id_new
   preset: ndm_product_id_new
-  required: true
 
 - field_name: name
   preset: ndm_name

--- a/ckanext/stcndm/schemas/generic.yaml
+++ b/ckanext/stcndm/schemas/generic.yaml
@@ -34,7 +34,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/indicator.yaml
+++ b/ckanext/stcndm/schemas/indicator.yaml
@@ -27,14 +27,13 @@ dataset_fields:
   preset: select
   choices:
     - label:
-        en: Indicators
-        fr: Indicateurs
+        en: Indicator
+        fr: Indicateur
       value: '12'
   required: true
 
 - field_name: top_parent_id
   preset: ndm_top_parent_id
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/publication.yaml
+++ b/ckanext/stcndm/schemas/publication.yaml
@@ -34,7 +34,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/pumf.yaml
+++ b/ckanext/stcndm/schemas/pumf.yaml
@@ -34,7 +34,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/service.yaml
+++ b/ckanext/stcndm/schemas/service.yaml
@@ -33,7 +33,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/video.yaml
+++ b/ckanext/stcndm/schemas/video.yaml
@@ -37,7 +37,6 @@ dataset_fields:
 
 - field_name: subject_codes
   preset: ndm_subject_codes
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/schemas/view.yaml
+++ b/ckanext/stcndm/schemas/view.yaml
@@ -34,7 +34,6 @@ dataset_fields:
 
 - field_name: top_parent_id
   preset: ndm_top_parent_id
-  required: true
 
 - field_name: product_id_new
   preset: ndm_product_id_new

--- a/ckanext/stcndm/validators.py
+++ b/ckanext/stcndm/validators.py
@@ -265,7 +265,9 @@ def create_product_id(key, data, errors, context):
             return
     elif data_set_type in general_data_types:
         if not top_parent_id or top_parent_id is missing:
-            errors[key].append(_('missing top_parent_id'))
+            errors[key].append(_('Unable to generate product_id_new: '
+                                 'missing top_parent_id'))
+            errors[('top_parent_id',)].append(_('Missing value'))
             return
         try:
             product_id_new = get_next_product_id(


### PR DESCRIPTION
making subject_codes or top_parent_id required breaks import with ckanapi
because the data in STC QA is bad

the create_product_id and create_product_name validators still force users
to provide values for these fields when entering data from the form but
allow ckanapi to import data with missing data.
