### PR TITLE
consume_transaction_file loads transactions from local file system

### DIFF
--- a/ckanext/stcndm/helpers.py
+++ b/ckanext/stcndm/helpers.py
@@ -58,6 +58,8 @@ def get_schema(org, dataset):
     Return a dict having fields in a given org for keys and the values stored
     for that field in the tmschema organization as a dict.
 
+    :param org:
+    :param dataset:
     :return: dict of dicts
     """
 
@@ -303,6 +305,9 @@ def codeset_choices(codeset_type):
     """
     Return a dictionary of {codeset_value: title} for the codeset_type
     passed
+    :param codeset_type:
+    :type codeset_type: str
+    :return dict
     """
     lc = ckanapi.LocalCKAN()
     results = lc.action.package_search(

--- a/ckanext/stcndm/logic/releases.py
+++ b/ckanext/stcndm/logic/releases.py
@@ -4,6 +4,8 @@ import datetime
 import ckan.logic as logic
 import ckan.plugins.toolkit as toolkit
 import ckanext.stcndm.helpers as stcndm_helpers
+import pylons.config as config
+import json
 
 _get_or_bust = logic.get_or_bust
 _stub_msg = {
@@ -201,6 +203,20 @@ def consume_transaction_file(context, data_dict):
                     value=value,
                     type=expected.__name__)})
         return value
+
+    if u'transactionFile' not in data_dict:
+        transaction_file = config.get('ckanext.stcndm.transaction_file')
+        if not transaction_file:
+            raise _ValidationError({
+                u'transactionFile': u'Path to transactionFile missing from'
+                                    u'CKAN config file'})
+        try:
+            transaction_file = open(transaction_file)
+            data_dict = json.load(transaction_file)
+        except (IOError, ValueError) as e:
+            raise _ValidationError({
+                u'transactionFile': e.message
+            })
 
     transaction_dict = my_get(data_dict, u'transactionFile', dict)
     daily_dict = my_get(transaction_dict, u'daily', dict)


### PR DESCRIPTION
If the transaction file is not passed in the webAPI call,
look up the path to the file in pylons config and load the file
from local file system
