### PR TITLE
Updated the ensure_release_exists method.

### DIFF
--- a/ckanext/stcndm/helpers.py
+++ b/ckanext/stcndm/helpers.py
@@ -623,10 +623,12 @@ def ensure_release_exists(product_id, context=None, ref_period=None):
         record[field_dst] = cast_to(val) if cast_to is not None else val
 
     requests.post(rsu, params={
-        'productType': product['type'],
+        'productType':  str(product['type']).capitalize(),
     }, data=json.dumps({
         'recordInfo': record
-    }))
+    }), headers={
+        'Content-Type': 'application/json'
+    })
 
 
 def get_parent_content_types(product_id):


### PR DESCRIPTION
It seems like call to the embargo web service were not working, but capitalizing the product type and explicitly setting the content type header _seems_ to have resolved the error.
