### PR TITLE
dguids and schema clean up

### DIFF
--- a/ckanext/stcndm/bin/massage/massage_geodescriptors.py
+++ b/ckanext/stcndm/bin/massage/massage_geodescriptors.py
@@ -50,7 +50,7 @@ while i < n:
             u'license_url': line.get(u'license_url', ''),
             u'license_id': line.get(u'license_id', ''),
         }
-        geodescriptor_code = line.get(u'tmsgcspecificcode_bi_tmtxtm', '')
+        geodescriptor_code = u'2011' + line.get(u'tmsgcspecificcode_bi_tmtxtm')
         if ';' in geodescriptor_code:
             line_out[u'aliased_codes'] = listify(geodescriptor_code)
             line_out[u'geodescriptor_code'] = line_out[u'geolevel_codes']
@@ -58,7 +58,7 @@ while i < n:
                 geolevel_code=line_out[u'geolevel_codes'].lower()
             )
         else:
-            line_out[u'geodescriptor_code'] = line.get(u'tmsgcspecificcode_bi_tmtxtm', '')
+            line_out[u'geodescriptor_code'] = geodescriptor_code
             line_out[u'name'] = u'geodescriptor-{geodescriptor_code}'.format(
                 geodescriptor_code=geodescriptor_code.lower()
             )

--- a/ckanext/stcndm/bin/massage/massage_product.py
+++ b/ckanext/stcndm/bin/massage/massage_product.py
@@ -230,7 +230,7 @@ def do_product(data_set):
     if in_and_def(u'geonamecode_bi_intxtm', data_set):
         result = listify(data_set[u'geonamecode_bi_intxtm'])
         if result:
-            product_out[u'geodescriptor_codes'] = result
+            product_out[u'geodescriptor_codes'] = [u'2011' + r for r in result]
 
     if in_and_def(u'hierarchyid_bi_strm', data_set):
         result = listify(data_set[u'hierarchyid_bi_strm'])
@@ -318,7 +318,7 @@ def do_product(data_set):
     if in_and_def(u'specificgeocode_bi_txtm', data_set):
         result = listify(data_set[u'specificgeocode_bi_txtm'])
         if result:
-            product_out[u'geodescriptor_codes'] = result
+            product_out[u'geodescriptor_codes'] = [u'2011' + r for r in result]
 
     if in_and_def(u'statusfcode_bi_strs', data_set):
         if data_set[u'statusfcode_bi_strs'] == '33':

--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -117,15 +117,6 @@ class STCNDMPlugin(p.SingletonPlugin):
 
         name = validated_data_dict.get(u'name')
         for item, value in validated_data_dict.iteritems():
-            # Don't bother indexing null fields.
-            if (
-                    not value or
-                    value == {u'en': u'', u'fr': u''} or
-                    value == {u'en': [], u'fr': []}
-            ):
-                index_data_dict.pop(item, None)
-                continue
-
             fs = field_schema.get(item)
 
             # Do not index any field that is not currently in the schema.
@@ -162,19 +153,6 @@ class STCNDMPlugin(p.SingletonPlugin):
                             value=value
                         )
                     ), ))
-
-            elif field_type == 'int':
-                if isinstance(value, list):
-                    try:
-                        index_data_dict[unicode(item)] = map(int, value)
-                    except ValueError:
-                        pass
-                else:
-                    try:
-                        index_data_dict[unicode(item)] = int(value)
-                    except ValueError:
-                        pass
-                continue
 
             # Numeric foreign keys that need to be looked up to retrieve
             # their multilingual labels for searching.

--- a/ckanext/stcndm/plugins.py
+++ b/ckanext/stcndm/plugins.py
@@ -200,7 +200,6 @@ class STCNDMPlugin(p.SingletonPlugin):
                                 {n: index_data_dict.get(n, []) + [v]}
                             )
 
-                    # index_data_dict[unicode(item)] = value
                 else:
                     desc = lookup_label(lookup, value, lookup_type)
 
@@ -222,6 +221,11 @@ class STCNDMPlugin(p.SingletonPlugin):
             elif item.endswith('_authors'):
                 index_data_dict[unicode(item)] = value
                 authors.extend(value)
+            elif item == u'geodescriptor_codes':
+                index_data_dict[u'dguid_codes'] == \
+                    index_data_dict[u'geodescriptor_codes'].copy()
+                index_data_dict[u'geodescriptor_codes'] = \
+                    [g[-4:] for g in index_data_dict[u'dguid_codes']]
             else:
                 index_data_dict[unicode(item)] = value
 
@@ -355,7 +359,8 @@ class STCNDMPlugin(p.SingletonPlugin):
             'get_child_datasets': helpers.get_child_datasets,
             'x2list': helpers.x2list,
             'set_related_id': helpers.set_related_id,
-            'changes_since': helpers.changes_since
+            'changes_since': helpers.changes_since,
+            'get_geolevel': helpers.get_geolevel,
         }
 
     def before_view(self, pkg_dict):

--- a/ckanext/stcndm/schemas/codeset.yaml
+++ b/ckanext/stcndm/schemas/codeset.yaml
@@ -26,6 +26,10 @@ dataset_fields:
     en: Type of Codeset
     fr: Genre de codeset
   preset: select
+  required: true
+  schema_field_type: string
+  schema_multivalued: false
+  schema_extras: true
   choices:
     - label:
         en: Content Type
@@ -39,15 +43,12 @@ dataset_fields:
         en: Geolevel
         fr: Geolevel
       value: 'geolevel'
-  required: true
-  schema_field_type: string
-  schema_multivalued: false
-  schema_extras: true
 
 - field_name: codeset_value
   label:
     en: The code value of the codeset (e.g. A0001)
     fr: La valeur du code du 'codeset' (p.e. A0001)
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false

--- a/ckanext/stcndm/schemas/correction.yaml
+++ b/ckanext/stcndm/schemas/correction.yaml
@@ -51,7 +51,7 @@ dataset_fields:
   preset: ndm_format
   form_snippet: multiple_select.html
   display_snippet: multiple_choice.html
-  validators: scheming_required scheming_multiple_choice
+  validators: ignore_empty scheming_multiple_choice
   output_validators: shortcode_output
   schema_field_type: string
   schema_multivalued: true

--- a/ckanext/stcndm/schemas/cube.yaml
+++ b/ckanext/stcndm/schemas/cube.yaml
@@ -76,7 +76,7 @@ dataset_fields:
 
 - field_name: archive_status_code
   preset: ndm_archive_status
-  validators: scheming_required scheming_choices archive_children_of_cube
+  validators: ignore_empty scheming_choices archive_children_of_cube
 
 - field_name: archive_date
   preset: ndm_archive_date
@@ -91,6 +91,7 @@ dataset_fields:
   label:
     en: Default View ID
     fr: ID de vue par défaut
+  validators: ignore_empty
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true

--- a/ckanext/stcndm/schemas/format.yaml
+++ b/ckanext/stcndm/schemas/format.yaml
@@ -32,7 +32,7 @@ dataset_fields:
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true
-  validators: remove_whitespace #scheming_required
+  validators: ignore_missing remove_whitespace
 
 - field_name: format_id
   label:

--- a/ckanext/stcndm/schemas/geodescriptor.yaml
+++ b/ckanext/stcndm/schemas/geodescriptor.yaml
@@ -39,6 +39,7 @@ dataset_fields:
   label:
     en: Geodescriptor Specific Code
     fr: Code spécifique du geodescriptor
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false
@@ -49,6 +50,7 @@ dataset_fields:
     en: Old Title
     fr: Ancien titre
   preset: fluent_text
+  validators: ignore_empty fluent_text
   schema_field_type: fluent
   schema_multivalued: false
   schema_extras: true

--- a/ckanext/stcndm/schemas/indicator.yaml
+++ b/ckanext/stcndm/schemas/indicator.yaml
@@ -49,7 +49,7 @@ dataset_fields:
     fr: Calculs
   form_snippet: repeating_text.html
   display_snippet: repeating_text.html
-  validators: repeating_text
+  validators: ignore_empty repeating_text
   output_validators: repeating_text_output
   schema_field_type: string
   schema_multivalued: true
@@ -62,6 +62,7 @@ dataset_fields:
   label:
     en: Coordinates
     fr: Coordonnées
+  validators: ignore_empty
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true
@@ -73,6 +74,7 @@ dataset_fields:
   label:
     en: Display Order
     fr: Ordre d'affichage
+  validators: ignore_empty
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true
@@ -102,6 +104,7 @@ dataset_fields:
   label:
     en: NDM States
     fr: États NDM
+  validators: ignore_empty
   schema_field_type: string
   schema_multivalued: true
   schema_extras: true
@@ -115,7 +118,7 @@ dataset_fields:
     fr: IDs de tables
   form_snippet: repeating_text.html
   display_snippet: repeating_text.html
-  validators: repeating_text
+  validators: ignore_empty repeating_text
   output_validators: repeating_text_output
   schema_field_type: string
   schema_multivalued: true

--- a/ckanext/stcndm/schemas/presets.yaml
+++ b/ckanext/stcndm/schemas/presets.yaml
@@ -18,7 +18,7 @@ presets:
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
 
 - preset_name: ndm_archive_date
@@ -28,7 +28,7 @@ presets:
       fr: Date d'archivage
     form_snippet: date.html
     display_snippet: date.html
-    validators: scheming_required isodate
+    validators: ignore_empty isodate
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -40,7 +40,7 @@ presets:
       fr: État d'archivage
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -70,7 +70,7 @@ presets:
       fr: Tableau terminé (CANSIM)
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -98,7 +98,7 @@ presets:
         value: '1'
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -108,6 +108,15 @@ presets:
     label:
       en: Census Grouping
       fr: Regroupement du recensement
+    form_snippet: multiple_select.html
+    display_snippet: multiple_choice.html
+    validators: ignore_empty scheming_multiple_choice
+    output_validators: scheming_multiple_choice_output
+    lookup: preset
+    schema_field_type: code
+    schema_multivalued: true
+    schema_extras: true
+    sorted_choices: true
     choices:
       - label:
           en: Parent
@@ -137,15 +146,6 @@ presets:
           en: Release 5
           fr: Émission 5
         value: '7'
-    form_snippet: multiple_select.html
-    display_snippet: multiple_choice.html
-    validators: scheming_required scheming_multiple_choice
-    output_validators: scheming_multiple_choice_output
-    lookup: preset
-    schema_field_type: code
-    schema_multivalued: true
-    schema_extras: true
-    sorted_choices: true
 
 - preset_name: ndm_census_years
   values:
@@ -154,7 +154,7 @@ presets:
       fr: Années de recensements
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -168,7 +168,7 @@ presets:
     schema_extras: true
     form_snippet: codeset_multiple_select.html
     display_snippet: codeset_multiple_choice.html
-    validators: ignore_missing codeset_multiple_choice
+    validators: ignore_empty codeset_multiple_choice
     output_validators: scheming_multiple_choice_output
     lookup: codeset
 
@@ -178,7 +178,7 @@ presets:
     schema_multivalued: false
     form_snippet: codeset_select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: codeset
 
 - preset_name: ndm_collection_methods
@@ -188,7 +188,7 @@ presets:
       fr: Méthode de collection
     form_snippet: multiple_select.html
     display_snippet: multiple_choice.html
-    validators: scheming_required scheming_multiple_choice
+    validators: ignore_empty scheming_multiple_choice
     output_validators: shortcode_output
     lookup: preset
     schema_field_type: code
@@ -270,7 +270,7 @@ presets:
     schema_extras: true
     form_snippet: codeset_multiple_select.html
     display_snippet: codeset_multiple_choice.html
-    validators: ignore_missing codeset_multiple_choice
+    validators: ignore_empty codeset_multiple_choice
     output_validators: scheming_multiple_choice_output
     lookup: codeset
     codeset_type: content_type
@@ -283,7 +283,7 @@ presets:
       fr: Niveau d'impact de la correction
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -305,7 +305,7 @@ presets:
       fr: Code ID de correction
     form_snippet: shortcode_multivalue.html
     display_snippet: shortcode_multivalue.html
-    validators: shortcode_validate
+    validators: ignore_empty shortcode_validate
     output_validators: shortcode_output
     schema_field_type: string
     schema_multivalued: false
@@ -318,7 +318,7 @@ presets:
       fr: Genre de correction
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -377,7 +377,7 @@ presets:
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
 
 - preset_name: ndm_digital_object_identifier
@@ -388,7 +388,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: string
     schema_multivalued: false
@@ -410,7 +410,7 @@ presets:
         value: '1'
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -427,7 +427,7 @@ presets:
     form_snippet: fluent_tags.html
     display_snippet: fluent_tags.html
     error_snippet: fluent_text.html
-    validators: fluent_tags
+    validators: ignore_empty fluent_tags
     output_validators: fluent_tags_output
     tag_validators: ndm_tag_name_validator
     form_attrs:
@@ -444,7 +444,7 @@ presets:
       fr: Date discontinué
     form_snippet: date.html
     display_snippet: date.html
-    validators: scheming_required isodate
+    validators: ignore_empty isodate
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -456,7 +456,7 @@ presets:
       fr: Affichage
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     create_validators: set_default_value(1)
     lookup: preset
     schema_field_type: code
@@ -483,7 +483,7 @@ presets:
       fr: Auteurs externes
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -495,7 +495,9 @@ presets:
     label:
       en: Feature Weight
       fr: Poids
-    schema_field_type: string
+    validators: ignore_empty convert_int
+    output_validators: convert_int
+    schema_field_type: int
     schema_multivalued: false
     schema_extras: true
 
@@ -506,7 +508,7 @@ presets:
       fr: Format du produit
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required # scheming_multiple_choice
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -596,6 +598,7 @@ presets:
     label:
       en: FRC
       fr: FRC
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -610,7 +613,7 @@ presets:
     schema_extras: true
     form_snippet: codeset_multiple_select.html
     display_snippet: codeset_multiple_choice.html
-    validators: ignore_missing codeset_multiple_choice
+    validators: ignore_empty codeset_multiple_choice
     output_validators: scheming_multiple_choice_output
     lookup: codeset
     codeset_type: frequency
@@ -623,7 +626,7 @@ presets:
       fr: Géo spécifique
     form_snippet: shortcode_multivalue.html
     display_snippet: shortcode_multivalue.html
-    validators: shortcode_validate
+    validators: ignore_empty shortcode_validate
     output_validators: shortcode_output
     lookup: geodescriptor
     schema_field_type: code
@@ -640,7 +643,7 @@ presets:
     schema_extras: true
     form_snippet: codeset_multiple_select.html
     display_snippet: codeset_multiple_choice.html
-    validators: ignore_missing codeset_multiple_choice
+    validators: ignore_empty codeset_multiple_choice
     output_validators: scheming_multiple_choice_output
     lookup: codeset
     codeset_type: geolevel
@@ -654,7 +657,7 @@ presets:
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -667,7 +670,7 @@ presets:
       fr: Identificateurs de variable IMDB
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -679,11 +682,13 @@ presets:
     label:
       en: Internal Authors
       fr: Auteurs internes
+    help_text:
+      en: Please enter semicolon separated names
+      fr: Veuillez entrer des noms séparés par des pointvirgules
     form_snippet: autocomplete.html
     display_snippet: repeating_text.html
-    validators: repeating_text_delimited
+    validators: ignore_empty repeating_text_delimited
     output_validators: repeating_text_output
-    form_blanks: 3
     schema_field_type: string
     schema_multivalued: true
     schema_extras: true
@@ -695,7 +700,7 @@ presets:
       fr: Nom de personnes ressource internes
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -710,7 +715,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -724,7 +729,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -735,6 +740,7 @@ presets:
     label:
       en: Issue Number
       fr: Numéro d'émission
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -750,7 +756,7 @@ presets:
     form_snippet: fluent_tags.html
     display_snippet: fluent_tags.html
     error_snippet: fluent_text.html
-    validators: fluent_tags
+    validators: ignore_empty fluent_tags
     output_validators: fluent_tags_output
     tag_validators: ndm_tag_name_validator
     form_attrs:
@@ -767,7 +773,7 @@ presets:
       fr: Langue
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -792,7 +798,7 @@ presets:
       fr: Heure de dernière diffusion
     form_snippet: datetime.html
     display_snippet: datetime.html
-    validators: scheming_isodatetime apply_archive_rules
+    validators: ignore_empty scheming_isodatetime apply_archive_rules
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -805,7 +811,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -816,6 +822,7 @@ presets:
       label:
         en: PE Code
         fr: Code PE
+      validators: ignore_empty
       schema_field_type: string
       schema_multivalued: false
       schema_extras: true
@@ -830,7 +837,7 @@ presets:
       fr: Heure de diffusion
     form_snippet: datetime.html
     display_snippet: datetime.html
-    validators: scheming_isodatetime
+    validators: ignore_empty scheming_isodatetime
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -842,7 +849,7 @@ presets:
       fr: Date de statut ancien
     form_snippet: date.html
     display_snippet: date.html
-    validators: scheming_required isodate
+    validators: ignore_empty isodate
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -852,6 +859,13 @@ presets:
     label:
       en: Load to OLC
       fr: Charger au OLC
+    form_snippet: select.html
+    display_snippet: select.html
+    validators: ignore_empty scheming_choices
+    lookup: preset
+    schema_field_type: code
+    schema_multivalued: false
+    schema_extras: true
     choices:
       - label:
           en: 'False'
@@ -861,13 +875,6 @@ presets:
           en: 'True'
           fr: 'Vrai'
         value: '1'
-    form_snippet: select.html
-    display_snippet: select.html
-    validators: scheming_required scheming_choices
-    lookup: preset
-    schema_field_type: code
-    schema_multivalued: false
-    schema_extras: true
 
 - preset_name: ndm_name
   values:
@@ -900,6 +907,7 @@ presets:
     label:
       en: Price
       fr: Prix
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -912,7 +920,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -986,17 +994,18 @@ presets:
     label:
       en: Product ID New
       fr: ID produit nouveau
+    validators: scheming_required remove_whitespace
     required: true
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
-    validators: remove_whitespace
 
 - preset_name: ndm_product_id_old
   values:
     label:
       en: Product ID Old
       fr: ID produit ancien
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -1006,6 +1015,7 @@ presets:
     label:
       en: Publication Year
       fr: Année de publication
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -1017,7 +1027,7 @@ presets:
       fr: État de publication
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1052,7 +1062,7 @@ presets:
       fr: Produits associés
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -1066,7 +1076,7 @@ presets:
       fr: Produits remplacés
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -1080,7 +1090,7 @@ presets:
       fr: Date de statut ROT
     form_snippet: date.html
     display_snippet: date.html
-    validators: scheming_required isodate
+    validators: ignore_empty isodate
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -1089,7 +1099,7 @@ presets:
   values:
     form_snippet: shortcode_multivalue.html
     display_snippet: shortcode_multivalue.html
-    validators: shortcode_validate
+    validators: ignore_empty shortcode_validate
     output_validators: shortcode_output
     schema_field_type: code
     schema_multivalued: true
@@ -1101,7 +1111,7 @@ presets:
       fr: État
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1151,9 +1161,9 @@ presets:
       fr: Sujets
     form_snippet: shortcode_multivalue.html
     display_snippet: shortcode_multivalue.html
-    validators: scheming_required shortcode_validate
-    create_validators: scheming_required shortcode_validate
-    output_validators: scheming_required shortcode_output
+    validators: ignore_empty shortcode_validate
+#    create_validators: shortcode_validate
+    output_validators: shortcode_output
     lookup: subject
     schema_field_type: code
     schema_multivalued: true
@@ -1167,7 +1177,7 @@ presets:
       fr: Anciens sujets
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: repeating_text
+    validators: ignore_empty repeating_text
     output_validators: repeating_text_output
     schema_field_type: string
     schema_multivalued: true
@@ -1180,7 +1190,7 @@ presets:
       fr: Affichage du sujet
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1214,7 +1224,7 @@ presets:
       fr: Participation au sondage
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1244,7 +1254,7 @@ presets:
       fr: Propriétaire du sondage
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1370,7 +1380,7 @@ presets:
       fr: Source
     form_snippet: shortcode_multivalue.html
     display_snippet: shortcode_multivalue.html
-    validators: shortcode_validate
+    validators: ignore_empty shortcode_validate
     output_validators: shortcode_output
     lookup: survey
     schema_field_type: code
@@ -1384,7 +1394,7 @@ presets:
       fr: État
     form_snippet: select.html
     display_snippet: select.html
-    validators: scheming_required scheming_choices
+    validators: ignore_empty scheming_choices
     lookup: preset
     schema_field_type: code
     schema_multivalued: false
@@ -1410,7 +1420,7 @@ presets:
     form_snippet: fluent_tags.html
     display_snippet: fluent_tags.html
     error_snippet: fluent_text.html
-    validators: fluent_tags
+    validators: ignore_empty fluent_tags
     output_validators: fluent_tags_output
     tag_validators: ndm_tag_name_validator
     form_attrs:
@@ -1434,7 +1444,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
 
 - preset_name: ndm_top_parent_id
@@ -1442,9 +1452,7 @@ presets:
     label:
       en: Top Parent ID
       fr: ID du parent du plus haut niveau
-    output_validators: scheming_required
-    create_validators: scheming_required
-    validators: scheming_required remove_whitespace
+    validators: ignore_empty remove_whitespace
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true
@@ -1456,7 +1464,7 @@ presets:
       fr: Pistage
     form_snippet: multiple_select.html
     display_snippet: multiple_choice.html
-    validators: scheming_required scheming_multiple_choice
+    validators: ignore_empty scheming_multiple_choice
     output_validators: shortcode_output
     lookup: preset
     schema_field_type: code
@@ -1551,6 +1559,9 @@ presets:
       en: URL
       fr: URL
     display_snippet: link.html
+    validators: ignore_empty
+    schema_field_type: string
+    schema_multivalued: false
 
 - preset_name: ndm_fluent_url
   values:
@@ -1560,7 +1571,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_link.html
     error_snippet: fluent_text.html
-    validators: fluent_text
+    validators: ignore_empty fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -1594,6 +1605,7 @@ presets:
     label:
       en: Volume and Number
       fr: Volume et nombre
+    validators: ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true

--- a/ckanext/stcndm/schemas/presets.yaml
+++ b/ckanext/stcndm/schemas/presets.yaml
@@ -12,14 +12,14 @@ presets:
     form_placeholder:
       en: Admin Notes
       fr: Notes
-    schema_field_type: fluent
-    schema_multivalued: false
-    schema_extras: true
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: true
 
 - preset_name: ndm_archive_date
   values:
@@ -366,19 +366,17 @@ presets:
     label:
       en: Description (Notes)
       fr: Description (Notes)
-    schema_field_type: fluent
-    schema_multivalued: false
-    schema_extras: false
     form_placeholder:
-      en: A detailed description of the dataset that will allow the user to determine
-        the nature and purpose of the data in the dataset.
-      fr: Une description détaillée de l’ensemble de données qui permettra à l'utilisateur
-        de connaître la nature et le but des données comprises dans l’ensemble de données.
+      en: A detailed description of the dataset that will allow the user to determine the nature and purpose of the data in the dataset.
+      fr: Une description détaillée de l’ensemble de données qui permettra à l'utilisateur de connaître la nature et le but des données comprises dans l’ensemble de données.
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: false
 
 - preset_name: ndm_digital_object_identifier
   values:
@@ -388,9 +386,9 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
-    schema_field_type: string
+    schema_field_type: fluent
     schema_multivalued: false
     schema_extras: true
 
@@ -424,15 +422,15 @@ presets:
     help_text:
       en: Please enter comma separated terms
       fr: Veuillez entrer des mots séparés par des virgules
-    form_snippet: fluent_tags.html
-    display_snippet: fluent_tags.html
-    error_snippet: fluent_text.html
-    validators: ignore_empty fluent_tags
-    output_validators: fluent_tags_output
-    tag_validators: ndm_tag_name_validator
     form_attrs:
       data-module: autocomplete
       data-module-tags:
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator
     schema_field_type: fluent
     schema_multivalued: true
     schema_extras: true
@@ -657,7 +655,7 @@ presets:
     form_snippet: fluent_markdown.html
     display_snippet: fluent_markdown.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -715,7 +713,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -729,7 +727,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -753,15 +751,15 @@ presets:
     help_text:
       en: Please enter comma separated terms
       fr: Veuillez entrer des mots séparés par des virgules
-    form_snippet: fluent_tags.html
-    display_snippet: fluent_tags.html
-    error_snippet: fluent_text.html
-    validators: ignore_empty fluent_tags
-    output_validators: fluent_tags_output
-    tag_validators: ndm_tag_name_validator
     form_attrs:
       data-module: autocomplete
       data-module-tags:
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator
     schema_field_type: fluent
     schema_multivalued: true
     schema_extras: true
@@ -811,7 +809,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -920,7 +918,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false
@@ -1417,15 +1415,15 @@ presets:
     help_text:
       en: Please enter comma separated terms
       fr: Veuillez entrer des mots séparés par des virgules
-    form_snippet: fluent_tags.html
-    display_snippet: fluent_tags.html
-    error_snippet: fluent_text.html
-    validators: ignore_empty fluent_tags
-    output_validators: fluent_tags_output
-    tag_validators: ndm_tag_name_validator
     form_attrs:
       data-module: autocomplete
       data-module-tags: ""
+    form_snippet: fluent_tags.html
+    display_snippet: fluent_tags.html
+    error_snippet: fluent_text.html
+    validators: fluent_tags
+    output_validators: fluent_tags_output
+    tag_validators: ndm_tag_name_validator
     schema_field_type: fluent
     schema_multivalued: true
     schema_extras: true
@@ -1435,17 +1433,17 @@ presets:
     label:
       en: Title
       fr: Titre
-    schema_field_type: fluent
-    schema_multivalued: false
-    schema_extras: false
     form_placeholder:
       en: Canada Border Wait Times
       fr: Temps d’attente à la frontière
     form_snippet: fluent_text.html
     display_snippet: fluent_text.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
+    schema_field_type: fluent
+    schema_multivalued: false
+    schema_extras: false
 
 - preset_name: ndm_top_parent_id
   values:
@@ -1571,7 +1569,7 @@ presets:
     form_snippet: fluent_text.html
     display_snippet: fluent_link.html
     error_snippet: fluent_text.html
-    validators: ignore_empty fluent_text
+    validators: fluent_text
     output_validators: fluent_text_output
     schema_field_type: fluent
     schema_multivalued: false

--- a/ckanext/stcndm/schemas/province.yaml
+++ b/ckanext/stcndm/schemas/province.yaml
@@ -25,6 +25,7 @@ dataset_fields:
     en: SGC Code
     fr: Code SGC
   required: true
+  validators: scheming_required
   schema_field_type: string
   schema_multivalued: false
   schema_extras: true
@@ -42,6 +43,7 @@ dataset_fields:
   label:
     en: Geotype
     fr: Géotype
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false
@@ -51,6 +53,7 @@ dataset_fields:
   label:
     en: Geolevel
     fr: Géolevel
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false
@@ -60,6 +63,7 @@ dataset_fields:
   label:
     en: Sort Order
     fr: Ordre du tri
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false

--- a/ckanext/stcndm/schemas/publication.yaml
+++ b/ckanext/stcndm/schemas/publication.yaml
@@ -163,7 +163,7 @@ dataset_fields:
 
 - field_name: load_to_olc_code
   preset: ndm_load_to_olc_code
-  validators: scheming_required scheming_choices ndm_child_inherits_value
+  validators: ignore_empty scheming_choices ndm_child_inherits_value
 
 - field_name: subjectold_codes
   preset: ndm_subjectold_codes

--- a/ckanext/stcndm/schemas/subject.yaml
+++ b/ckanext/stcndm/schemas/subject.yaml
@@ -24,6 +24,7 @@ dataset_fields:
   label:
     en: Subject Code
     fr: Code du sujet
+  validators: scheming_required
   required: true
   schema_field_type: string
   schema_multivalued: false
@@ -49,6 +50,7 @@ dataset_fields:
     en: Please enter comma separated terms
     fr: Veuillez entrer des mots séparés par des virgules
   preset: fluent_tags
+  validators: ignore_empty fluent_tags
   tag_validators: ndm_tag_name_validator
   schema_field_type: fluent
   schema_multivalued: true

--- a/ckanext/stcndm/schemas/survey.yaml
+++ b/ckanext/stcndm/schemas/survey.yaml
@@ -79,6 +79,7 @@ dataset_fields:
   label:
     en: Survey Instance Item
     fr: Élement d'instance de sondage
+  validators: ignore_empty
   schema_field_type: int
   schema_multivalued: false
   schema_extras: true
@@ -87,6 +88,7 @@ dataset_fields:
   label:
     en: Survey Item
     fr: Élement de sondage
+  validators: ignore_empty
   schema_field_type: int
   schema_multivalued: false
   schema_extras: true
@@ -96,6 +98,7 @@ dataset_fields:
     en: ISP URL
     fr: URL d'ISP
   preset: fluent_link
+  validators: ignore_empty fluent_text
   schema_field_type: fluent
   schema_multivalued: false
   schema_extras: true
@@ -108,6 +111,7 @@ dataset_fields:
     en: Question URL
     fr: URL de question
   preset: fluent_link
+  validators: ignore_empty fluent_text
   schema_field_type: fluent
   schema_multivalued: false
   schema_extras: true
@@ -135,6 +139,7 @@ dataset_fields:
     en: Survey URL
     fr: URL du sondage
   preset: fluent_link
+  validators: ignore_empty fluent_text
   schema_field_type: fluent
   schema_multivalued: false
   schema_extras: true

--- a/ckanext/stcndm/templates/scheming/form_snippets/autocomplete.html
+++ b/ckanext/stcndm/templates/scheming/form_snippets/autocomplete.html
@@ -5,7 +5,7 @@
     id='field-' + field.field_name,
     label=h.scheming_language_text(field.label),
     placeholder=h.scheming_language_text(field.form_placeholder),
-    value=data[field.field_name]|join('; ') + ';',
+    value=data[field.field_name]|join('; ') + ';' if data[field.field_name] else '',
     error=errors[field.field_name],
     classes=['control-medium'],
     attrs={'data-multilist': 'field-' + field.field_name + '-list', 'style': 'width: 100%'},

--- a/ckanext/stcndm/validators.py
+++ b/ckanext/stcndm/validators.py
@@ -76,14 +76,10 @@ def shortcode_validate(key, data, errors, context):
         return
 
     value = data[key]
-    if value is missing:
-        data[key] = json.dumps([])
+    if value is missing or value == u'':
         return
 
     if isinstance(value, basestring):
-        if not value:
-            data[key] = json.dumps([])
-            return
         try:
             if isinstance(json.loads(value), list):
                 return

--- a/conf/solr/schema-dev.xml
+++ b/conf/solr/schema-dev.xml
@@ -19,23 +19,33 @@
 <schema name="ckan" version="2.3">
 
     <types>
-        <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-        <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+        <fieldType name="string" class="solr.StrField" sortMissingLast="true"
+                   omitNorms="true"/>
+        <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"
+                   omitNorms="true"/>
         <fieldtype name="binary" class="solr.BinaryField"/>
-        <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-        <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true"
-                   positionIncrementGap="0"/>
-        <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-        <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true"
-                   positionIncrementGap="0"/>
-        <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-        <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true"
-                   positionIncrementGap="0"/>
-        <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-        <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true"
-                   positionIncrementGap="0"/>
-        <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
-        <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+        <fieldType name="int" class="solr.TrieIntField" precisionStep="0"
+                   omitNorms="true" positionIncrementGap="0"
+                   sortMissingLast="true"/>
+        <fieldType name="float" class="solr.TrieFloatField" precisionStep="0"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="long" class="solr.TrieLongField" precisionStep="0"
+                   omitNorms="true" positionIncrementGap="0"
+                   sortMissingLast="true"/>
+        <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tint" class="solr.TrieIntField" precisionStep="8"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8"
+                   omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="date" class="solr.TrieDateField" omitNorms="true"
+                   precisionStep="0" positionIncrementGap="0"/>
+        <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true"
+                   precisionStep="6" positionIncrementGap="0"/>
 
         <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
             <analyzer type="index">
@@ -329,6 +339,7 @@
         <field name="correction_type_code_desc_en" type="text_en" indexed="true" stored="true" multiValued="false"/>
         <field name="correction_type_code_desc_fr" type="text_fr" indexed="true" stored="true" multiValued="false"/>
         <field name="default_view_id" type="text" indexed="true" stored="true" multiValued="false"/>
+        <field name="dguid_codes" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="digital_object_identifier" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="dimension_members_en" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="dimension_members_fr" type="string" indexed="true" stored="true" multiValued="true"/>

--- a/conf/solr/solrconfig-dev.xml
+++ b/conf/solr/solrconfig-dev.xml
@@ -16,9 +16,9 @@
  limitations under the License.
 -->
 
-<!-- 
+<!--
      For more details about configurations options that may appear in
-     this file, see http://wiki.apache.org/solr/SolrConfigXml. 
+     this file, see http://wiki.apache.org/solr/SolrConfigXml.
 -->
 <config>
     <!-- In all configuration below, a prefix of "solr." for class names
@@ -35,7 +35,7 @@
          that you fully re-index after changing this setting as it can
          affect both how text is indexed and queried.
     -->
-    <luceneMatchVersion>4.4</luceneMatchVersion>
+    <luceneMatchVersion>5.3.1</luceneMatchVersion>
 
     <!-- <lib/> directives can be used to instruct Solr to load an Jars
          identified and use them to resolve any "plugins" specified in
@@ -72,17 +72,19 @@
          The examples below can be used to load some solr-contribs along
          with their external dependencies.
       -->
-    <lib dir="../../../contrib/extraction/lib" regex=".*\.jar"/>
-    <lib dir="../../../dist/" regex="solr-cell-\d.*\.jar"/>
+    <lib dir="${solr.install.dir:}/contrib/extraction/lib" regex=".*\.jar"/>
+    <lib dir="${solr.install.dir:}/dist/" regex="solr-cell-\d.*\.jar"/>
 
-    <lib dir="../../../contrib/clustering/lib/" regex=".*\.jar"/>
-    <lib dir="../../../dist/" regex="solr-clustering-\d.*\.jar"/>
+    <lib dir="${solr.install.dir:}/contrib/clustering/lib/" regex=".*\.jar"/>
+    <lib dir="${solr.install.dir:}/dist/" regex="solr-clustering-\d.*\.jar"/>
 
-    <lib dir="../../../contrib/langid/lib/" regex=".*\.jar"/>
-    <lib dir="../../../dist/" regex="solr-langid-\d.*\.jar"/>
+    <lib dir="${solr.install.dir:}/contrib/langid/lib/" regex=".*\.jar"/>
+    <lib dir="${solr.install.dir:}/dist/" regex="solr-langid-\d.*\.jar"/>
 
-    <lib dir="../../../contrib/velocity/lib" regex=".*\.jar"/>
-    <lib dir="../../../dist/" regex="solr-velocity-\d.*\.jar"/>
+    <lib dir="${solr.install.dir:}/contrib/velocity/lib" regex=".*\.jar"/>
+    <lib dir="${solr.install.dir:}/dist/" regex="solr-velocity-\d.*\.jar"/>
+
+    <lib dir="${solr.install.dir:}/server/solr-webapp/webapp/WEB-INF/lib/" regex="lucene-analyzers-common-5.3.1.jar"/>
 
     <!-- an exact 'path' can be used instead of a 'dir' to specify a
          specific jar file.  This will cause a serious error to be logged


### PR DESCRIPTION
dguids: 
- modified massage scripts to naively convert geodescriptors to dguids by pre-ending
  '2011' to the geodescriptor_codes
- modified UpdateProductGeo to accept and expect dguids instead of geodescriptors
- added a dguid_codes field to solr schema
- modified before_index to store both dguid_codes and geodescriptor_codes in solr

schema cleanup:
- convert feature_weight to int in ckan schema, not longer need int casting in before_index
- ignore empty values in ckan schema, no longer need to drop them in before_index
  NOTE: ignore_empty doesn't work with fluent fields
