### PR TITLE
More dguid fixes

### DIFF
--- a/ckanext/stcndm/helpers.py
+++ b/ckanext/stcndm/helpers.py
@@ -795,3 +795,15 @@ def get_geolevel(dguid_or_geodescriptor):
                                     code=dguid_or_geodescriptor
                                     )
         })
+
+
+def get_dguid_from_pkg_id(pkg_id):
+    """
+    Given the package id, return the dguid of the package
+
+    :param pkg_id:
+    :return:
+    """
+    lc = ckanapi.LocalCKAN()
+    result = lc.action.package_show(**{u'id': pkg_id})
+    return result.get(u'geodescriptor_code')

--- a/ckanext/stcndm/logic/common.py
+++ b/ckanext/stcndm/logic/common.py
@@ -1236,7 +1236,7 @@ def update_product_geo(context, data_dict):
         # directly on the package.
         geo.clear_geodescriptors_for_package(pkg_dict['product_id_new'])
         for geo_code in dguids:
-            geo.update_relationship(pkg_dict['product_id_new'], geo_code[4:])
+            geo.update_relationship(pkg_dict['product_id_new'], geo_code)
     else:
         # Non-data products simply have the geodescriptors assigned to the
         # package.


### PR DESCRIPTION
- Let updtate_product_geo store dguids with vintages in datastore
- In before_index, the code to treat dguids was unreachable
- before_index needed to pull dguids from the datastore too.
