### PR TITLE
make ignore_empty play nice with repeating_text and last_release_date

### DIFF
--- a/ckanext/stcndm/schemas/presets.yaml
+++ b/ckanext/stcndm/schemas/presets.yaml
@@ -154,7 +154,7 @@ presets:
       fr: Années de recensements
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -481,7 +481,7 @@ presets:
       fr: Auteurs externes
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -493,7 +493,7 @@ presets:
     label:
       en: Feature Weight
       fr: Poids
-    validators: ignore_empty convert_int
+    validators: convert_int ignore_empty
     output_validators: convert_int
     schema_field_type: int
     schema_multivalued: false
@@ -668,7 +668,7 @@ presets:
       fr: Identificateurs de variable IMDB
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -685,7 +685,7 @@ presets:
       fr: Veuillez entrer des noms séparés par des pointvirgules
     form_snippet: autocomplete.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text_delimited
+    validators: repeating_text_delimited ignore_empty
     output_validators: repeating_text_output
     schema_field_type: string
     schema_multivalued: true
@@ -698,7 +698,7 @@ presets:
       fr: Nom de personnes ressource internes
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -794,9 +794,9 @@ presets:
     label_time:
       en: Last Release Time
       fr: Heure de dernière diffusion
-    form_snippet: datetime.html
-    display_snippet: datetime.html
-    validators: ignore_empty scheming_isodatetime apply_archive_rules
+    form_snippet: datetime_tz.html
+    display_snippet: datetime_tz.html
+    validators: scheming_isodatetime_tz convert_to_json_if_datetime ignore_empty apply_archive_rules
     schema_field_type: date
     schema_multivalued: false
     schema_extras: true
@@ -824,21 +824,6 @@ presets:
       schema_field_type: string
       schema_multivalued: false
       schema_extras: true
-
-- preset_name: ndm_release_date
-  values:
-    label:
-      en: Release Date
-      fr: Date de diffusion
-    label_time:
-      en: Release Time
-      fr: Heure de diffusion
-    form_snippet: datetime.html
-    display_snippet: datetime.html
-    validators: ignore_empty scheming_isodatetime
-    schema_field_type: date
-    schema_multivalued: false
-    schema_extras: true
 
 - preset_name: ndm_legacy_date
   values:
@@ -1060,7 +1045,7 @@ presets:
       fr: Produits associés
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -1074,7 +1059,7 @@ presets:
       fr: Produits remplacés
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     form_blanks: 3
     schema_field_type: string
@@ -1175,7 +1160,7 @@ presets:
       fr: Anciens sujets
     form_snippet: repeating_text.html
     display_snippet: repeating_text.html
-    validators: ignore_empty repeating_text
+    validators: repeating_text ignore_empty
     output_validators: repeating_text_output
     schema_field_type: string
     schema_multivalued: true
@@ -1464,7 +1449,7 @@ presets:
     label:
       en: Top Parent ID
       fr: ID du parent du plus haut niveau
-    validators: ignore_empty remove_whitespace
+    validators: remove_whitespace ignore_empty
     schema_field_type: string
     schema_multivalued: false
     schema_extras: true


### PR DESCRIPTION
I had applied the ignore_empty validator to repeating_text fields and last_release_date.
This didn't work because ignore_empty was executed before the repeating_text or
scheming_datetime validators and the field value was always "missing".

Changing the order in which the validators are applied fixed the problem.
