### PR TITLE
solr schema type was dropping all product ids not of length 8, 15, 19…

### DIFF
--- a/conf/solr/schema-dev.xml
+++ b/conf/solr/schema-dev.xml
@@ -245,7 +245,7 @@
             <analyzer type="index">
                 <tokenizer class="solr.PatternTokenizerFactory" pattern=";\s*"/>
                 <filter class="solr.EdgeNGramFilterFactory" minGramSize="8" maxGramSize="20"/>
-                <filter class="solr.PatternReplaceFilterFactory" pattern="^(.{9,14}|.{16,18})$" replacement=""/>
+                <!--<filter class="solr.PatternReplaceFilterFactory" pattern="^(.{9}|.{11,14}|.{16,18})$" replacement=""/>-->
                 <filter class="solr.LengthFilterFactory" min="8" max="20"/>
             </analyzer>
             <analyzer type="query">


### PR DESCRIPTION
… or 20

it turns out views have a product id of length 10. CKAN couldn't find any views
